### PR TITLE
Update templates.rst

### DIFF
--- a/doc/source/packaging/templates.rst
+++ b/doc/source/packaging/templates.rst
@@ -5,19 +5,19 @@ Templates
 #########
 
 Starting a new project from scratch is a tedious task. To simplify the starting process
-and make it more dynamic, the `ansys-templates`_ tool was created . Using this
-template ensures that any project rendered is compliant with the latest PyAnsys
+and make project generation more dynamic, the `ansys-templates`_ tool was created. Using this
+tool ensures that any project rendered is compliant with the latest PyAnsys
 coding and API style guidelines.
 
 The ``ansys-templates`` tool
 ============================
 
-The `ansys-templates`_ tool is a command line interface that provides a
-collection of templates. When you use this tool to create a new PyAnsys project, your
+The `ansys-templates`_ tool is a command-ine interface that provides a
+collection of templates. When you use this tool to create a PyAnsys project, your
 responses to the several questions that are asked result in dynamic project generation.
 
-Please, follow the `ansys-templates installation guide`_ to get the latest stable
-version installed in your system.
+To install the latest stable version of this tool, see `Getting started`_ in the
+Ansys templates documentation. Here are important links for this tool:
 
 - **Repository**: https://github.com/ansys/ansys-templates
 - **Documentation**: https://templates.ansys.com
@@ -26,36 +26,38 @@ version installed in your system.
 
 .. note::
 
-   Open a new issue in the `ansys-templates issues board`_ if you encounter any
-   problem during the installation or usage of the tool.
+   If you encounter any problem during the installation or usage of this tool,
+   open a new issue on the `ansys-templates issues board`_.
 
 
 PyAnsys available templates
 ===========================
 
-There are two templates that can be used as the basis for creating new PyAnsys
-projects ``pyansys`` and ``pyansys-advanced``. 
+There are two templates that you can use to create PyAnsys
+projects: ``pyansys`` and ``pyansys-advanced``. 
 
 .. important::
 
-   Install `ansys-templates`_ to access these templates. For more information on
-   how to use this tool, see `ansys-templates user guide`_.
+   To access these templates, you must install `ansys-templates`_.
+   For information on how to use this tool, see `User guide`_ in the
+   Ansys templates documentation.
 
 
 PyAnsys template 
 ----------------
 
 The ``pyansys`` template ships only with the required directories and files to
-quickly setup a PyAnsys compliant project:
+quickly set up a PyAnsys-compliant project. This template provides the following:
 
-- Provides a ``src/ansys/product/library/`` layout
-- Includes a ``setup.py`` file
-- Generates a ``doc/`` and a ``tests/`` directories
-- Generic ``.gitignore`` for Python libraries
-- Includes building, doc, and test requirements files
+- A ``src/ansys/product/library/`` directory
+- A ``setup.py`` file
+- Generation of ``doc/`` and ``tests/`` directories
+- A generic ``.gitignore`` file for Python libraries
+- Build, doc, and test requirements files
 - Metadata files like ``README.rst`` and ``LICENSE``
 
-Create a new project based on the ``pyansys`` template by running:
+To create a project based on the ``pyansys`` template, run
+this code:
 
 .. code:: bash
 
@@ -66,23 +68,24 @@ PyAnsys advanced template
 -------------------------
 
 The ``pyansys-advanced`` template is an enhanced version of the ``pyansys`` template.
-It ships with the same files as this last template, except it:
+It ships with the same files as the preceding template but also includes additional
+features:
 
 - Allows you to select the project file (``setup.py`` or ``pyproject.toml``)
 - Uses `Tox`_ for testing and task automation
 - Includes GitHub Actions for CI purposes
 - Uses `pre-commit`_ for checking coding style
 
-Create a project based on the ``pyansys-advanced`` template with:
+To create a project based on the ``pyansys-advanced`` template, run this code:
 
 .. code:: bash
 
    ansys-templates new pyansys-advanced
 
 .. _ansys-templates: https://templates.ansys.com/index.html
-.. _ansys-templates installation guide: https://templates.ansys.com/getting_started/index.html
-.. _ansys-templates user guide: https://templates.ansys.com/user_guide/index.html
-.. _ansys-templates issues board:  https://github.com/ansys/ansys-templates/issues
+.. _Getting started: https://templates.ansys.com/version/stable/getting_started/index.html
+.. _User guide: https://templates.ansys.com/version/stable/user_guide/index.html
+.. _ansys-templates issues board: https://github.com/ansys/ansys-templates/issues
 .. _flit: https://flit.readthedocs.io/en/latest/
 .. _poetry: https://python-poetry.org/
 .. _pre-commit: https://pre-commit.com/


### PR DESCRIPTION
The two links to specific sections of the Ansys templates documentation were broken. I fixed them--using the path with stable as the version. (I hope this is correct.) I also did an overall edit of the topic, including changing reference links to have better display text.