### PR TITLE
Add a "Glossary of abbreviations" page to the dev guide

### DIFF
--- a/doc/source/getting-started/abbr.rst
+++ b/doc/source/getting-started/abbr.rst
@@ -57,12 +57,12 @@ operating system uses to denote line endings in files.
 D - E - F
 ---------
 
-**DevEco*
+**DevEco**
 
 Developer Ecosystem: The name of the Ansys team responsible for the
 `Ansys Developer <https://developer.ansys.com/>_` portal.
 
-**DNS*
+**DNS**
 
 Domain name system: A hierarchical and distributed naming system for computers,
 services, and other resources on the internet or other Internet Protocol (IP) networks.
@@ -82,7 +82,7 @@ Don't repeat yourself: A principle of software development aimed at reducing
 repetition of software patterns, replacing them with abstractions or using
 data normalization to avoid redundancy.
 
-**EOL*
+**EOL**
 
 End-of-line: One or more invisible characters that denote line endings in files.
 Each operating system manages EOL characters in its own way. Windows uses the
@@ -92,14 +92,14 @@ Linux and Mac use only a line feed (LF).
 G - H - I
 ---------
 
-**gRPC*
+**gRPC**
 
 gRPC: A high performance, open source, universal Remote Procedure Call (RPC) framework.
 gRPC can efficiently connect services in and across data centers with pluggable support
 for load balancing, tracing, health checking, and authentication.
 
 
-**IP*
+**IP**
 
 Intellectual property: A category of property that includes intangible creations of
 the human intellect. Of the many types of IP, the best known are patents, copyrights,

--- a/doc/source/getting-started/abbr.rst
+++ b/doc/source/getting-started/abbr.rst
@@ -67,7 +67,7 @@ Developer Ecosystem: The name of the Ansys team responsible for the
 Domain name system: A hierarchical and distributed naming system for computers,
 services, and other resources on the internet or other Internet Protocol (IP) networks.
 Just like a telephone directory translates names to phone numbers, DNS translates domain names
-into IP addresses, which are numerical labels assigned to every device connected
+to IP addresses, which are numerical labels assigned to every device connected
 to a computer network that uses the Internet Protocol for communication.
 
 **DPF**

--- a/doc/source/getting-started/abbr.rst
+++ b/doc/source/getting-started/abbr.rst
@@ -1,0 +1,222 @@
+.. _ref_abbreviations:
+
+Glossary of abbreviations
+=========================
+
+Like all technical documentation, the documentation for PyAnsys libraries
+includes lots of abbreviations, which is a general term that includes not
+only abbreviations but also acronyms and initialisms.
+
+On the first use of an abbreviation that might be unfamiliar to the developer
+community, the documentation for a PyAnsys library provides the longer word
+or phrase. For your convenience, this page provides a glossary of all these
+abbreviations.
+
+A - B - C
+---------
+
+**ACE**
+
+Ansys Customer Excellence: The Ansys organization responsible for ensuring
+customer success with Ansys products.
+
+**AEDT**
+
+Ansys Electronics Desktop: An Ansys product with the best-in-class solvers
+for electronics simulations.
+
+**APDL**
+APDL (Ansys Parametric Design Language): A powerful structured scripting language
+used to interact with the Ansys Mechanical solver. See also MAPDL, a fine element
+analysis program driven by APDL.
+
+**API**
+
+Application program interface: A set of rules that enable different apps
+to communicate with each other. An API is a type of software interface,
+offering a service to other pieces of software.
+
+**CI/CD**
+
+Continuous integration/continuous delivery: The practice of automating the
+integration of code changes from multiple developers into a single
+codebase so that the code can be built, tested, and delivered to production-ready
+environments for approval.
+
+**CLA**
+
+Contributor license agreement: An agreement defining the terms under
+which intellectual property has been contributed to a project or company,
+typically for software under an open source license.
+
+**CRLF**
+
+Carriage return, line feed: The invisible characters that the Windows
+operating system uses to denote line endings in files.
+
+D - E - F
+---------
+
+**DevEco*
+
+Developer Ecosystem: The name of the Ansys team responsible for the
+`Ansys Developer <https://developer.ansys.com/>_` portal.
+
+**DNS*
+
+Domain name system: A hierarchical and distributed naming system for computers,
+services, and other resources on the internet or other Internet Protocol (IP) networks.
+Just like a phonebook translates names to phone numbers, DNS translates domain names
+into IP addresses, which are numerical labels assigned to every device connected
+to a computer network that uses the Internet Protocol for communication.
+
+**DPF**
+Data Processing Framework: An Ansys product that provides numerical simulation users
+and engineers with a toolbox for accessing and transforming simulation data. With DPF,
+you can perform complex preprocessing or postprocessing of large amounts of simulation
+data within a simulation workflow.
+
+**DRY**
+
+Don't repeat yourself: A principle of software development aimed at reducing
+repetition of software patterns, replacing them with abstractions or using
+data normalization to avoid redundancy.
+
+**EOL*
+
+End-of-line: One or more invisible characters that denote line endings in files.
+Each operating system manages EOL characters in its own way. Windows uses the
+original DOS convention of a carriage return plus a line feed (CRLF), while
+Linux and Mac use only a line feed (LF).
+
+G - H - I
+---------
+
+**gRPC*
+
+gRPC: A high performance, open source, universal Remote Procedure Call (RPC) framework.
+gRPC can efficiently connect services in and across data centers with pluggable support
+for load balancing, tracing, health checking, and authentication.
+
+
+**IP*
+
+Intellectual property: A category of property that includes intangible creations of
+the human intellect. Of the many types of IP, the best known are patents, copyrights,
+trademarks, and trade secrets.
+
+Internet Protocol: The network layer communications protocol in the Internet protocol
+suite for relaying datagrams across network boundaries. Its routing function enables
+internetworking and essentially establishes the Internet.
+
+J - K- L
+--------
+
+**LF**
+
+Line feed: The invisible character that the Linux and Mac operating systems use to
+denote line endings in files.
+
+M - N - O
+---------
+
+**MAPDL**
+
+Mechanical APDL (Ansys Parametric Design Language): A finite element analysis program
+driven by APDL. APDL and MAPDL can be used for many tasks, ranging from creating
+geometries for analysis to setting up sophisticated solver settings for highly complex
+analyses. 
+
+**OSS**
+
+Open source software: Computer software that is released under a license in
+which the copyright holder grants users the rights to use, study, change,
+and distribute the software and its source code to anyone and for any purpose.
+Open source software may be developed in a collaborative public manner.
+
+P - Q - R
+---------
+
+**PIM**
+Product Instance Management: The PIM API is a gRPC API, enabling both library
+and app developers to start a product in a remote environment and communicate
+with its API. The PIM API is not intended to manage stateless services, to be
+a job management system, or a fully featured service orchestration API. Its
+purpose is to expose a minimum feature set for managing service-oriented apps.
+
+**PMM**
+
+Product marketing manager: Title of an Ansys person who can approve an open
+source project for an Ansys product for public release.
+
+**PyPA**
+
+Python Package Authority: A working group that maintains a core set of software projects
+used in Python packaging. The software developed through the PyPA is used to package,
+share, and install Python software and to interact with indexes of downloadable
+Python software such as PyPI, the Python Package Index.
+
+**PyPI**
+Python Package Index: A repository of software for the Python programming language.
+PyPI helps you find and install software developed and shared by the Python community.
+
+**REST**
+
+Representational state transfer: A software architectural style that provides
+interoperability between computer systems over the internet. REST is based on
+simple and standardized protocols, like HTTP, which is the backbone of the
+internet. It emphasizes a stateless client-server interaction, meaning each
+request should contain all the necessary information to be understood by the
+server, without relying on any previous interactions. This simplicity and
+standardization make it easy for different systems to communicate and exchange
+data effectively.
+
+**RPC**
+
+Remote procedure call: A powerful software communication protocol used in
+distributed client-server programs. An RPC is a request message initiated
+by a client program to a known remote server to execute a specified procedure
+with supplied parameters. The remote server sends a response to the client,
+and the app continues its process. RPC is more efficient than RST in terms of
+speed, memory, and payload size. Typically, the use of REST should be limited
+to short messages transferred via JSON files, and gRPC should be used for
+large data transfers and bidirectional streaming.
+
+**RMI**
+
+Remote method invocation: An API that allows an object to invoke a method
+on an object that exits in another address space, which could be on the same
+machine or on a remote machine. The Java RMI is the object-oriented equivalent of
+a remote procedure call (RPC) for Java, with support for direct transfer of serialized
+Java classes and distributed garbage-collection.
+
+S - T - U
+---------
+
+**SSH**
+
+Secure shell protocol: A cryptographic network protocol for operating network
+services securely over an unsecured network. Its most notable applications
+are remote login and command-line execution.
+
+**TDD**
+
+Test-drive development: A software development process that relies on software
+requirements being converted to test cases before software is fully developed.
+Software development is then tracked by repeatedly testing the software
+against all use cases.
+
+V - W - X
+---------
+
+**WSL2**
+
+Windows Subsystem for Linux: A Windows development environment that enables
+running a GNU/Linux environment, including most command-line tools, utilities,
+and apps, directly on Windows, unmodified, without the overhead of a traditional
+virtual machine or dual-boot setup.
+
+Y - X
+-----
+
+(No Y or Z entries exist presently.)

--- a/doc/source/getting-started/abbr.rst
+++ b/doc/source/getting-started/abbr.rst
@@ -4,8 +4,8 @@ Glossary of abbreviations
 =========================
 
 Like all technical documentation, the documentation for PyAnsys libraries
-includes lots of abbreviations, which is a general term that includes not
-only abbreviations but also acronyms and initialisms.
+includes lots of abbreviations, which is a general term that also includes
+acronyms and initialisms.
 
 On the first use of an abbreviation that might be unfamiliar to the developer
 community, the documentation for a PyAnsys library provides the longer word
@@ -66,7 +66,7 @@ Developer Ecosystem: The name of the Ansys team responsible for the
 
 Domain name system: A hierarchical and distributed naming system for computers,
 services, and other resources on the internet or other Internet Protocol (IP) networks.
-Just like a phonebook translates names to phone numbers, DNS translates domain names
+Just like a telephone directory translates names to phone numbers, DNS translates domain names
 into IP addresses, which are numerical labels assigned to every device connected
 to a computer network that uses the Internet Protocol for communication.
 

--- a/doc/source/getting-started/index.rst
+++ b/doc/source/getting-started/index.rst
@@ -45,6 +45,7 @@ ecosystem. Examples include:
    basic
    administration
    componentization
+   abbr
 
 .. _PyAEDT: https://github.com/ansys/PyAEDT
 .. _PyMAPDL: https://github.com/ansys/pymapdl
@@ -53,23 +54,23 @@ ecosystem. Examples include:
 Contributing to this guide
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you would like to contribute to this development guide, maintainers gladly 
-review all pull requests. Please follow the :ref:`Documentation style`.
+review all pull requests. For more information, see :ref:`Documentation style`.
 
-This repository uses the `pre-commit <https://pre-commit.com/>`_ library to
+This repository uses `pre-commit <https://pre-commit.com/>`_ to
 automate style checking. To use it, enter your Python environment and install
-it with::
+``pre-commit`` with this command::
 
    pip install pre-commit
 
-You can then run it manually with::
+You can then run ``pre-commit`` manually with this command::
 
    pre-commit run --all-files
 
 This performs various style and spelling checks to ensure your contributions
 meet minimum coding style and documentation standards.
 
-You can make sure that these checks are always run prior to ``git commit`` by
-installing a pre-commit as a git hook with::
+You can make sure that these checks are always run prior to ``git commit``
+running them by installing ``pre-commit`` as a git hook with this command::
 
   pre-commit install
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -29,13 +29,13 @@
            :link: how-to/index
            :link-type: doc
     
-           Detailed step-by-step guidelines.
+           Step-by-step guidelines.
 
         .. grid-item-card:: :octicon:`repo` Abstractions
            :link: abstractions/index
            :link-type: doc
 
-           Detailed explanations of the PyAnsys architecture.
+           Explanations of the PyAnsys architecture.
 
 
 .. card:: Style guidelines

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -8,6 +8,7 @@ CI/CD
 CLI
 Codespell
 dataframes
+datagrams
 dependabot
 Dependabot
 Dev
@@ -28,7 +29,9 @@ github
 GitHub Actions
 Hotfixes
 hotfixes
+initialisms
 initializer
+internetworking
 Isort
 isort
 linenos
@@ -42,6 +45,7 @@ numpydoc
 Parametrizing
 parametrizing
 PAT
+pluggable
 Postprocessing
 postprocessing
 Protobuf


### PR DESCRIPTION
This PR adds a "Glossary of abbreviations" page to the "Getting started" section of the developer's guide. To create this glossary, I've skimmed the pages of the developer's guide and the names of public PyAnsys repositories. The intent is to grow this glossary page with abbreviations used in all PyAnsys libraries and then add a reference to this page in the guide in each PyAnsys library.

NOTE: In skimming the developer's guide, I did notice a lot of content that should be modified. I hope to do this in a future PR soon.