### PR TITLE
Fixed links in rst files

### DIFF
--- a/doc/source/doc-style/index.rst
+++ b/doc/source/doc-style/index.rst
@@ -24,7 +24,7 @@ The documentation for a PyAnsys library should contain:
 * Module, class, method, and function docstrings. See 
   :ref:`docstrings`.
 * Full gallery of examples. See `PyMAPDL Examples
-  <https://mapdldocs.pyansys.com/examples/index.html>`_.
+  <https://examples.mapdl.docs.pyansys.com/>`_.
 * General content on installing, using, and contributing.
 * Link to the library's documentation from the repository's README file.
 

--- a/doc/source/getting-started/basic.rst
+++ b/doc/source/getting-started/basic.rst
@@ -16,7 +16,7 @@ library, visit one of these links:
 If you want to create, develop, or contribute to a PyAnsys library, 
 visit these links:
 
-* `PyAnsys Developer's Guide <https://dev.docs.pyansys.com/>`_
+* `PyAnsys Developer's Guide <https://github.com/ansys/pyansys-dev-guide>`_
 * `Ansys Sphinx Theme Documentation <https://github.com/ansys/ansys-sphinx-theme>`_
 * `gRPC Hello-world Example <https://github.com/ansys/pyansys-helloworld>`_
 * `Material Example Data <https://github.com/ansys/example-data>`_

--- a/doc/source/getting-started/basic.rst
+++ b/doc/source/getting-started/basic.rst
@@ -7,8 +7,8 @@ libraries that interface with Ansys products or services. To try out a
 library, visit one of these links:
 
 * `PyAEDT`_
-* `PyDPF-Core <https://github.com/ansys/DPF-Core>`_
-* `PyDPF-Post <https://github.com/ansys/DPF-Post>`_
+* `PyDPF-Core <https://github.com/ansys/pydpf-core>`_
+* `PyDPF-Post <https://github.com/ansys/pydpf-post>`_
 * `PyMAPDL`_
 * `PyMAPDL Legacy Reader <https://github.com/ansys/pymapdl-reader>`_
 * `PyPIM <https://github.com/ansys/pypim>`_
@@ -16,7 +16,7 @@ library, visit one of these links:
 If you want to create, develop, or contribute to a PyAnsys library, 
 visit these links:
 
-* `PyAnsys Developer's Guide <https://github.com/ansys/about>`_
+* `PyAnsys Developer's Guide <https://dev.docs.pyansys.com/>`_
 * `Ansys Sphinx Theme Documentation <https://github.com/ansys/ansys-sphinx-theme>`_
 * `gRPC Hello-world Example <https://github.com/ansys/pyansys-helloworld>`_
 * `Material Example Data <https://github.com/ansys/example-data>`_

--- a/doc/source/getting-started/basic.rst
+++ b/doc/source/getting-started/basic.rst
@@ -26,7 +26,7 @@ PROTO files, create coverage reports, and report on system coverage:
 
 * `pyansys-protos-generator <https://github.com/ansys/pyansys-protos-generator>`_
 * `example-coverage <https://github.com/ansys/example-coverage>`_
-* `system-reporting-tool <https://github.com/ansys/system-reporting-tool>`_
+* `pyansys-tools-report <https://github.com/ansys/pyansys-tools-report>`_
 
 Quick start guide
 -----------------

--- a/doc/source/how-to/dns-configuration.rst
+++ b/doc/source/how-to/dns-configuration.rst
@@ -17,7 +17,7 @@ for your documentation, refer to `Managing a custom domain for your GitHub Pages
 DNS TXT verification
 --------------------
 
-Once a CNAME is registered under the ``docs.pyansys.com`` domain, the next step is
+Once a CNAME is registered under the ``pyansys.com`` domain, the next step is
 to perform a DNS TXT verification. All PyAnsys subdomains are required by Ansys'
 IT department to provide a DNS TXT verification. To verify a new CNAME for an
 organization, refer to `Verifying a domain for your organization site`_. This guide

--- a/doc/source/how-to/dns-configuration.rst
+++ b/doc/source/how-to/dns-configuration.rst
@@ -33,6 +33,7 @@ PyAnsys verified domains
 
 In the `PyAnsys GitHub organization`_, this domain has been verified:
 
+* ``pyansys.com``
 * ``docs.pyansys.com``
 
 .. warning::

--- a/doc/source/how-to/dns-configuration.rst
+++ b/doc/source/how-to/dns-configuration.rst
@@ -6,7 +6,7 @@ online under the following canonical name (CNAME) convention:
 
 ``https://<product>.docs.pyansys.com``
 
-To request a CNAME for the ``docs.pyansys.com`` domain, contact the
+To request a CNAME for the ``pyansys.com`` domain, contact the
 `PyAnsys Core Team`_, so one of the members can handle the 
 creation of the requested PyAnsys subdomain.
 

--- a/doc/source/how-to/dns-configuration.rst
+++ b/doc/source/how-to/dns-configuration.rst
@@ -25,7 +25,7 @@ shows how to create DNS TXT verification elements for GitHub Pages sites.
 
 .. warning::
 
-    Only users with privilege access to the ``docs.pyansys.com`` DNS zone can
+    Only users with privilege access to the ``pyansys.com`` DNS zone can
     perform this operation. Contact the `PyAnsys Core Team`_ if needed.
 
 PyAnsys verified domains

--- a/doc/source/how-to/dns-configuration.rst
+++ b/doc/source/how-to/dns-configuration.rst
@@ -6,9 +6,9 @@ online under the following canonical name (CNAME) convention:
 
 ``https://<product>.docs.pyansys.com``
 
-To request a CNAME for the ``pyansys.com`` domain, contact
-`Maxime Rey`_, `Roberto Pastor Muela`_ or `Alex Kaszynski`_. Any of these members
-can handle the creation of the requested PyAnsys subdomain.
+To request a CNAME for the ``docs.pyansys.com`` domain, contact the
+`PyAnsys Core Team`_, so one of the members can handle the 
+creation of the requested PyAnsys subdomain.
 
 Once the CNAME is created, repository administrators can configure their published
 documentation in GitHub pages to be exposed through it. To configure the CNAME
@@ -17,7 +17,7 @@ for your documentation, refer to `Managing a custom domain for your GitHub Pages
 DNS TXT verification
 --------------------
 
-Once a CNAME is registered under the ``pyansys.com`` domain, the next step is
+Once a CNAME is registered under the ``docs.pyansys.com`` domain, the next step is
 to perform a DNS TXT verification. All PyAnsys subdomains are required by Ansys'
 IT department to provide a DNS TXT verification. To verify a new CNAME for an
 organization, refer to `Verifying a domain for your organization site`_. This guide
@@ -25,16 +25,14 @@ shows how to create DNS TXT verification elements for GitHub Pages sites.
 
 .. warning::
 
-    Only users with privilege access to the ``pyansys.com`` DNS zone can
-    perform this operation. Contact `Maxime Rey`_, `Roberto Pastor Muela`_
-    or `Alex Kaszynski`_ if needed.
+    Only users with privilege access to the ``docs.pyansys.com`` DNS zone can
+    perform this operation. Contact the `PyAnsys Core Team`_ if needed.
 
 PyAnsys verified domains
 ------------------------
 
-In the `PyAnsys GitHub organization`_, these domains have been verified:
+In the `PyAnsys GitHub organization`_, this domain has been verified:
 
-* ``pyansys.com``
 * ``docs.pyansys.com``
 
 .. warning::
@@ -59,8 +57,8 @@ This is better explained with the following examples:
 Case scenario - **protected** subdomain
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Consider that the domain ``pyansys.com`` has been verified for the `PyAnsys GitHub organization`_.
-- This CNAME is requested: ``subdomain.pyansys.com``.
+- Consider that the domain ``docs.pyansys.com`` has been verified for the `PyAnsys GitHub organization`_.
+- This CNAME is requested: ``subdomain.docs.pyansys.com``.
 
 This CNAME can only be used by repositories inside the `PyAnsys GitHub organization`_.
 Any attempt by an external user to take over this CNAME is identified and rejected by GitHub.
@@ -68,8 +66,8 @@ Any attempt by an external user to take over this CNAME is identified and reject
 Case scenario - **vulnerable** subdomain
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- The domain ``pyansys.com`` has been verified for the `PyAnsys GitHub organization`_.
-- This CNAME is requested: ``subsubdomain.subdomain.pyansys.com``.
+- The domain ``docs.pyansys.com`` has been verified for the `PyAnsys GitHub organization`_.
+- This CNAME is requested: ``subsubdomain.subdomain.docs.pyansys.com``.
 
 This CNAME **can** be used by external users for their repositories. For this reason,
 you must avoid creating CNAME requests that are not verified by the organization.
@@ -99,9 +97,7 @@ Thus, it is important that you follow these guidelines:
    Links
 
 .. _PyAnsys DNS Zones: https://portal.azure.com/#@ansys.com/resource/subscriptions/2870ae10-53f8-46b1-8971-93761377c38b/resourceGroups/pyansys/providers/Microsoft.Network/dnszones/pyansys.com/overview
-.. _Maxime Rey: https://teams.microsoft.com/l/chat/0/0?users=maxime.rey@ansys.com
-.. _Roberto Pastor Muela: https://teams.microsoft.com/l/chat/0/0?users=roberto.pastormuela@ansys.com
-.. _Alex Kaszynski: https://teams.microsoft.com/l/chat/0/0?users=alexander.kaszynski@ansys.com
+.. _PyAnsys Core Team: mailto:pyansys.core@ansys.com
 .. _PyAnsys GitHub organization: https://github.com/ansys
 .. _Managing a custom domain for your GitHub Pages site: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
 .. _Verifying a domain for your organization site: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/verifying-your-custom-domain-for-github-pages#verifying-a-domain-for-your-organization-site

--- a/doc/source/how-to/dns-configuration.rst
+++ b/doc/source/how-to/dns-configuration.rst
@@ -31,7 +31,7 @@ shows how to create DNS TXT verification elements for GitHub Pages sites.
 PyAnsys verified domains
 ------------------------
 
-In the `PyAnsys GitHub organization`_, this domain has been verified:
+In the `PyAnsys GitHub organization`_, these domains have been verified:
 
 * ``pyansys.com``
 * ``docs.pyansys.com``

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -466,7 +466,7 @@ The resulting PDF and intermediate LaTeX files are created in the
 Enabling multi-version documentation
 ------------------------------------
 With the release of `pyansys/actions@v4
-<https://actions.docs.pyansys.com/version/stable/index.html>`_ , projects can
+<https://actions.docs.ansys.com/version/stable/index.html>`_ , projects can
 benefit from multi-version documentation. Projects taking advantage of this
 feature need to apply different configurations according to their level of
 maturity.
@@ -522,7 +522,7 @@ released versions.
     shown by default in the documentation drop-down button. To show more versions,
     use the ``render-last`` variable in the `pyansys/actions/doc-deploy-stable
     action
-    <https://actions.docs.pyansys.com/version/stable/doc-actions/index.html#doc-deploy-stable-action>`_.
+    <https://actions.docs.ansys.com/version/stable/doc-actions/index.html#doc-deploy-stable-action>`_.
 
 If you require support for migrating to the multi-version documentation, email
 `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
@@ -640,7 +640,7 @@ workflow:
 Multi-version migration from ``pyansys/actions@v3``  to ``pyansys/actions@v4``
 ------------------------------------------------------------------------------
 Projects using the multi-version feature should upgrade to `pyansys/actions@v4
-<https://actions.docs.pyansys.com/version/stable/index.html>`_ or higher to
+<https://actions.docs.ansys.com/version/stable/index.html>`_ or higher to
 benefit from stable links. This is achieved by introducing a new layout that is
 not compatible with older `pyansys/actions` versions.
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -27,7 +27,7 @@ Documentation sources
 
 The generation of PyAnsys documentation uses `Sphinx
 <https://www.sphinx-doc.org/en/master/>`__ and an Ansys-branded theme
-(`ansys-sphinx-theme <https://github.com/ansys/Sansys-sphinx-theme>`_) to
+(`ansys-sphinx-theme <https://github.com/ansys/ansys-sphinx-theme>`_) to
 assemble content in:
 
 - Docstrings
@@ -154,7 +154,7 @@ For comprehensive syntax information, see the `reStrucutredText Markup Specifica
 <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html>`_.
 
 Because you need to be familiar with the content in the `PyAnsys Developer's
-Guide <dev.docs.pyansys.com/>`_, explore its HTML pages and then the RST files
+Guide <https://dev.docs.pyansys.com/index.html>`_, explore its HTML pages and then the RST files
 in its `repository <https://github.com/ansys/dev-guide>`_. This should help
 you to understand the syntax and see how RST files are nested to create this guide.
 
@@ -680,7 +680,7 @@ adding the ``dev`` path to the URL as follows:
 For example, consider PyAEDT documentation:
 
 - The URL for documentation of the latest stable release is `<https://aedt.docs.pyansys.com/>`_.
-- The URL for documentation of the latest development version is `<https://aedt.docs.pyansys.com/dev/>`_.
+- The URL for documentation of the latest development version is `<https://aedt.docs.pyansys.com/version/dev/>`_.
 
 The latest development versions of both the library and its documentation are
 automatically kept up to date via GitHub actions.
@@ -699,7 +699,7 @@ GitHub pull request. For more information, see :ref:`Build documentation`.
 
 .. _GitHub Pages: https://pages.github.com/
 .. _GitHub Actions: https://github.com/features/actions
-.. _PyMAPDL Documentation: https://mapdldocs.pyansys.com/
+.. _PyMAPDL Documentation: https://mapdl.docs.pyansys.com/
 .. _pyansys/pymapdl-docs: https://github.com/ansys/pymapdl-docs
 .. _gh-pages: https://github.com/ansys/dev-guide/tree/gh-pages
 .. _enabling GitHub pages: https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site#creating-your-site

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -169,7 +169,7 @@ sections in your library documentation:
 - ``User guide`` describes how to use basic features of the library.
 - ``API reference`` documents API resources provided by the library.
 - ``Examples`` provides fully fledged examples for using the library.
-- ``Contributing`` refers to the `PyAnsys Developer's Guide <dev.docs.pyansys.com/>`_
+- ``Contributing`` refers to the `PyAnsys Developer's Guide`_
   for overall guidance and provides library-specific contribution information.
 
 

--- a/doc/source/how-to/logging.rst
+++ b/doc/source/how-to/logging.rst
@@ -5,7 +5,7 @@ guidelines are best practices discovered through implementing logging services
 and modules within PyAnsys libraries. Suggestions and improvements are welcomed.
 
 Visit the `Official Python Logging Tutorial
-<https://docs.python.org/es/3/howto/logging.html>`_ for logging techniques. In
+<https://docs.python.org/3/howto/logging.html>`_ for logging techniques. In
 particular, see:
 
 - `Python Basic Logging Tutorial <https://docs.python.org/3/howto/logging.html#basic-logging-tutorial>`_
@@ -162,7 +162,7 @@ of the global and instance loggers.
 
 You can find the source for this example logger in the collapsible section below
 and in the ``dev_guide`` repository at `pyansys_logging.py
-<https://github.com/ansys/dev-guide/blob/main/logging/pyansys_logging.py>`_.
+<https://github.com/ansys/pyansys-dev-guide/blob/main/doc/source/how-to/code/pyansys_logging.py>`_.
 
 .. collapse:: Example PyAnsys Custom Logger Module
 


### PR DESCRIPTION
Hi @jorgepiloto, I have a few questions:

In [doc/source/how-to/dns-configuration.rst](https://github.com/ansys/pyansys-dev-guide/compare/doc/fix-links?expand=1#diff-a1ac5cc6232feb6e57b5695a66998392f172cf00b93462750087516eece4ed4b), should pyansys.com be docs.pyansys.com? 

Here are some other links I couldn't find:

In dev.docs.pyansys.com/getting-started/basic.html:
system-reporting-tool: https://github.com/ansys/system-reporting-tool
	- Is this the system reporting tool? [ansys/pyansys-tools-report](https://github.com/ansys/pyansys-tools-report)

In dev.docs.pyansys.com/how-to/documenting.html:
actions.docs.pyansys.com is not a secure website/it says there isn't a GitHub Page site, so I couldn't update these links below

- pyansys/actions/doc-deploy-stable action:  https://actions.docs.pyansys.com/version/stable/doc-actions/index.html#doc-deploy-stable-action
- pyansys/actions@v4:  https://actions.docs.pyansys.com/version/stable/index.html - page not found