### PR TITLE
fix: doc build issue with toml code block

### DIFF
--- a/doc/source/coding-style/formatting-tools.rst
+++ b/doc/source/coding-style/formatting-tools.rst
@@ -25,7 +25,7 @@ The minimum `black`_ configuration for a PyAnsys project should look like this:
 .. code-block:: toml
 
     [tool.black]
-    line-length: "<length>"
+    line-length = "<length>"
 
 
 Isort
@@ -67,7 +67,7 @@ The configuration for `flake8`_ must be specified in a ``.flake8`` file.
 
    [flake8]
    max-line-length = 88
-   extend-ignore = E203
+   extend-ignore = 'E203'
 
 Flake8 has many options that can be set within the configuration file.
 For more information, see this `Flake8 documentation topic

--- a/doc/source/coding-style/required-standard.rst
+++ b/doc/source/coding-style/required-standard.rst
@@ -15,7 +15,7 @@ Required ``pyproject.toml`` configuration
 .. code-block:: toml
 
     [tool.black]
-    line-length: "<length>"
+    line-length = "<length>"
 
     [tool.isort]
     profile = "black"
@@ -45,7 +45,7 @@ The following ``.flake8`` file is also required:
 
    [flake8]
    max-line-length = 88
-   extend-ignore = E203
+   extend-ignore = 'E203'
 
 
 Required ``pre-commit`` configuration

--- a/doc/source/how-to/packaging.rst
+++ b/doc/source/how-to/packaging.rst
@@ -38,9 +38,8 @@ system`:
             [project]
             dependencies = [
                 "ansys-api-service==X.Y.Z",
-                "matplotlib >= 3.5.2",
+                "matplotlib>=3.5.2",
                 "numpy",
-                ...
             ]
 
     .. tab-item:: poetry
@@ -51,7 +50,6 @@ system`:
             ansys-api-service = "^X.Y.Z"
             matplotlib = "^3.5.2"
             numpy = "*"
-            ...
 
     .. tab-item:: setuptools
 

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,4 +1,4 @@
-Sphinx==7.1.1
+Sphinx==7.2.6
 ansys-sphinx-theme==0.12.5
 sphinx-copybutton==0.5.2
 sphinx_toolbox==3.5.0


### PR DESCRIPTION
Fix the warnings while building documentation. The warnings indicate that the documentation builder is having difficulty lexing certain code blocks with the "toml" lexer. https://github.com/ansys/pyansys-dev-guide/actions/runs/6940459281/job/18879453184#step:4:3073