### PR TITLE
docs: adding a `commit-naming conventions` section and updating `links.rst` and `basics.rst`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,7 +42,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "Contribute",
-            "url": "https://dev.docs.pyansys.com/dev/how-to/contributing.html",
+            "url": "https://dev.docs.pyansys.com/how-to/contributing.html",
             "icon": "fa fa-wrench",
         },
     ],

--- a/doc/source/content-writing/content-contrib-setup/essentials.rst
+++ b/doc/source/content-writing/content-contrib-setup/essentials.rst
@@ -47,7 +47,7 @@ for this guide:
    :alt: **About** area with link to the *PyAnsys developer's guide*
 
 You can also view the documentation for public PyAnsys libraries from the
-`PyAnsys <PyAnsys_landing_page_>`_ landing page or from the Ansys Python Manager by
+`PyAnsys <PyAnsys_>`_ landing page or from the Ansys Python Manager by
 selecting **Help > PyAnsys Documentation**. For more information about this Python QA
 app, see :ref:`Ansys_Python_Manager`.
 

--- a/doc/source/getting-started/basic.rst
+++ b/doc/source/getting-started/basic.rst
@@ -1,7 +1,7 @@
 PyAnsys project organization
 ============================
 
-The `PyAnsys project <https://docs.pyansys.com/>`_ is a collection of many
+The `PyAnsys project <PyAnsys>`_ is a collection of many
 Python packages for using Ansys products through Python. The
 `Ansys organization <Ansys GitHub organization_>`_ on GitHub contains
 several repositories with Python libraries for interfacing with Ansys
@@ -9,26 +9,28 @@ products or services. To go to the repository for a main PyAnsys library,
 visit one of these links:
 
 * `PyAEDT`_
-* `PyDPF-Core <https://github.com/ansys/pydpf-core>`_
-* `PyDPF-Post <https://github.com/ansys/pydpf-post>`_
+* `PyAnsys Geometry`_
+* `PyDPF-Core`_
+* `PyDPF-Post`_
 * `PyMAPDL`_
-* `PyMAPDL Legacy Reader <https://github.com/ansys/pymapdl-reader>`_
-* `PyPIM <https://github.com/ansys/pypim>`_
+* `PyMAPDL Legacy Reader`_
+* `PyMechanical`_
+* `PyPIM`_
 
 If you want to create, develop, or contribute to a PyAnsys library, 
 visit these links:
 
-* `PyAnsys developer's guide <https://github.com/ansys/pyansys-dev-guide>`_
+* `PyAnsys developer's guide <dev_guide_repo_>`_
 * `Ansys Sphinx Theme documentation <ansys-sphinx-theme-doc_>`_
-* `gRPC Hello-world example <https://github.com/ansys/pyansys-helloworld>`_
-* `Material example data <https://github.com/ansys/example-data>`_
+* `gRPC Hello-world example <grpc_hello_world_>`_
+* `Material example data <example_data_>`_
 
 Developers use the following tools to generate library packages from 
 PROTO files, create coverage reports, and report on system coverage:
 
-* `pyansys-protos-generator <https://github.com/ansys/pyansys-protos-generator>`_
-* `example-coverage <https://github.com/ansys/example-coverage>`_
-* `pyansys-tools-report <https://github.com/ansys/pyansys-tools-report>`_
+* `pyansys-protos-generator <pyansys_proto_generator_>`_
+* `example-coverage <example_coverage_>`_
+* `pyansys-tools-report <pyansys_tools_report_>`_
 
 PyAnsys repository creation
 ---------------------------

--- a/doc/source/getting-started/basic.rst
+++ b/doc/source/getting-started/basic.rst
@@ -1,7 +1,7 @@
 PyAnsys project organization
 ============================
 
-The `PyAnsys project <PyAnsys>`_ is a collection of many
+The `PyAnsys project <PyAnsys_>`_ is a collection of many
 Python packages for using Ansys products through Python. The
 `Ansys organization <Ansys GitHub organization_>`_ on GitHub contains
 several repositories with Python libraries for interfacing with Ansys

--- a/doc/source/how-to/contributing.rst
+++ b/doc/source/how-to/contributing.rst
@@ -194,17 +194,17 @@ development. They help core developers know what kind of
 changes any given branch is introducing before looking at the code.
 
 -  ``fix/``: Bug fixes, patches, or experimental changes that are
-   minor
+   minor.
 -  ``feat/``: Changes that introduce a new feature or significant
-   addition
+   addition.
 -  ``junk/``: Experimental changes that can be deleted if they go
-   stale
--  ``maint/``: General maintenance of the repository or CI routines
--  ``doc/``: Changes pertaining only to documentation
+   stale.
+-  ``maint/``: General maintenance of the repository or CI routines.
+-  ``docs/``: Changes pertaining only to documentation.
 -  ``no-ci/``: Low-impact activity that should not trigger CI
-   routines
--  ``testing/``: Improvements or changes to testing
--  ``release/``: Releases (see below)
+   routines.
+-  ``testing/`` or ``test/``: Improvements or changes to testing.
+-  ``release/``: Releases (see below).
 
 Push your branch
 ----------------
@@ -238,6 +238,30 @@ or someone else with write permission must merge your PR and then delete your PR
 .. admonition:: Always delete your PR branch after merging it into the main branch.
 
    You can set up automatic deletion of branches in **Settings > General > Pull Requests**.
+
+
+Commit-naming conventions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Following the `conventional commits standards <conventional_commit_types_>`_,
+helps to streamline development and improve the :ref:`Changelog <ref_changelog_file>`
+quality. Here is a list of the most common commit types:
+
+-  ``fix:``: Bug fixes.
+-  ``feat:``: Changes that introduce a new feature or significant addition.
+-  ``docs:``: Changes pertaining only to documentation.
+-  ``style``: Changes that do not affect the meaning of the code (white-space,
+   formatting, missing semi-colons, etc.).
+-  ``refactor:``: A code change that neither fixes a bug nor adds a feature.
+-  ``perf:``: A code change that improves performance.
+-  ``test:``: Improvements or changes to testing.
+-  ``build:``: Changes that affect the build system or external dependencies
+   (example scopes: pip, npm, make).
+-  ``ci:``: Changes to the CICD configuration files and scripts.
+-  ``chore:``: Other changes that don't modify the code (example scopes: release,
+   versioning, etc.).
+- ``revert:``: Reverts a previous commit.
+
 
 Use GitHub CLI
 --------------

--- a/doc/source/how-to/testing.rst
+++ b/doc/source/how-to/testing.rst
@@ -522,8 +522,3 @@ project `template <https://github.com/ansys/template/>`_.
 
 .. literalinclude:: code/tests.yml     
    :language: yaml
-
-
-.. _Test Driven Development (TDD): https://en.wikipedia.org/wiki/Test-driven_development
-.. _codecov.io: https://app.codecov.io/gh/pyansys
-

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -80,6 +80,7 @@
 .. _VSC_doc: https://code.visualstudio.com/Docs
 .. _VSC_doc_setup: https://code.visualstudio.com/docs/setup/setup-overview
 .. _unzip: https://7-zip.org/
+.. _conventional_commit_types: https://github.com/commitizen/conventional-commit-types/blob/master/index.json
 
 .. #Sphinx-related links
 .. _PyData_Sphinx_theme: https://github.com/pydata/pydata-sphinx-theme

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -5,8 +5,7 @@
 .. # Emails
 .. _pyansys_core_email: pyansys.core@ansys.com
 
-.. #content writing resources
-.. _Google_dev_doc_style_guide: https://developers.google.com/style
+.. #Content writing resources
 .. _Markdown_GitHub_flavored_spec: https://github.github.com/gfm/
 .. _Material_for_Sphinx: https://bashtage.github.io/sphinx-material/basics.html
 .. _Python_doc: https://www.python.org/doc/
@@ -21,7 +20,6 @@
 .. _Ansys_templates: https://github.com/ansys/ansys-templates
 .. _ansys-templates: https://templates.ansys.com/index.html
 .. _Git: https://git-scm.com/
-
 .. _Git Extensions: https://gitextensions.github.io/
 .. _Notepadpp: https://notepad-plus-plus.org/
 .. _pip: https://pypi.org/project/pip/
@@ -33,25 +31,46 @@
 .. _VSC: https://code.visualstudio.com/
 .. _array_creation: https://numpy.org/doc/stable/user/basics.creation.html
 
-.. #Ansys libraries:
-.. _Ansys_Python_Manager_doc: https://installer.docs.pyansys.com/version/stable/
-.. _dev_guide_repo: https://github.com/ansys/pyansys-dev-guide
-.. _Fluent_faq_page: https://fluent.docs.pyansys.com/version/stable/getting_started/faqs.html
-.. _join_ansys_organization: https://myapps.microsoft.com/signin/8f67c59b-83ac-4318-ae96-f0588382ddc0?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706
-.. _join_ansys_internal_organization: https://myapps.microsoft.com/signin/42c0fa04-03f2-4407-865e-103af6973dae?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706
-.. _Links_for_dev_guide: https://github.com/ansys/pyansys-dev-guide/trr/blob/main/doc/source/links.rst
-.. _Links_for_pymapdl: https://github.com/ansys/pymapdl/blob/main/doc/source/links.rst
-.. _PyAnsys_geometry_Docker_containers: https://geometry.docs.pyansys.com/version/stable/getting_started/docker/index.html
-.. _PyAnsys_landing_page: https://docs.pyansys.com/version/stable/
-.. _python_installer_qt_ui_releases: https://github.com/ansys/python-installer-qt-gui/releases
-.. _PyMAPDL_config: https://github.com/ansys/pymapdl/blob/main/doc/source/conf.py
-.. _pyansys/pymapdl-docs: https://github.com/ansys/pymapdl-docs
-.. _PyMAPDL Documentation: https://mapdl.docs.pyansys.com/
-.. _review_bot: https://github.com/ansys/review-bot
-
 .. #Ansys
 .. _ansys: https://www.ansys.com/
 .. _ansys_help: https://ansyshelp.ansys.com
+.. _join_ansys_organization: https://myapps.microsoft.com/signin/8f67c59b-83ac-4318-ae96-f0588382ddc0?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706
+.. _join_ansys_internal_organization: https://myapps.microsoft.com/signin/42c0fa04-03f2-4407-865e-103af6973dae?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706
+
+.. #PyAnsys repositories
+.. _ansys-api-mapdl: https://pypi.org/project/ansys-api-mapdl/
+.. _ansys/template: https://github.com/ansys/template
+.. _Ansys_Python_Manager_doc: https://installer.docs.pyansys.com/version/stable/
+.. _dev_guide_repo: https://github.com/ansys/pyansys-dev-guide
+.. _example_data: https://github.com/ansys/example-data
+.. _example_coverage: https://github.com/ansys/example-coverage
+.. _Fluent_faq_page: https://fluent.docs.pyansys.com/version/stable/getting_started/faqs.html
+.. _grpc_chunk_stream_demo: https://github.com/ansys/grpc_chunk_stream_demo
+.. _grpc_hello_world: https://github.com/ansys/pyansys-helloworld
+.. _Links_for_pymapdl: https://github.com/ansys/pymapdl/blob/main/doc/source/links.rst
+.. _PyAEDT: https://github.com/ansys/pyaedt
+.. _PyAnsys_geometry_Docker_containers: https://geometry.docs.pyansys.com/version/stable/getting_started/docker/index.html
+.. _PyAnsys: https://docs.pyansys.com/version/stable/
+.. _PyAnsys Bot: https://github.com/apps/pyansys-bot
+.. _pyansys_proto_generator: https://github.com/ansys/pyansys-protos-generator
+.. _pyansys_tools_report: https://github.com/ansys/pyansys-tools-report
+.. _PyDPF-Core: https://github.com/ansys/pydpf-core
+.. _PyDPF-Post: https://github.com/ansys/pydpf-post
+.. _PyAnsys Geometry: https://github.com/ansys/pyansys-geometry
+.. _PyMAPDL: https://github.com/ansys/pymapdl
+.. _PyMAPDL_config: https://github.com/ansys/pymapdl/blob/main/doc/source/conf.py
+.. _PyMAPDL Documentation: https://mapdl.docs.pyansys.com/
+.. _PyMAPDL Legacy Reader: https://github.com/ansys/pymapdl-reader
+.. _PyMechanical: https://github.com/ansys/pymechanical
+.. _PyMeilisearch: https://pymeilisearch.docs.ansys.com/
+.. _PyPIM: https://github.com/ansys/pypim
+.. _python_installer_qt_ui_releases: https://github.com/ansys/python-installer-qt-gui/releases
+.. _review_bot: https://github.com/ansys/review-bot
+
+.. #PyAnsys related links
+.. _PyAnsys PyPI: https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi
+.. _PyAnsys DNS Zones: https://portal.azure.com/#@ansys.com/resource/subscriptions/2870ae10-53f8-46b1-8971-93761377c38b/resourceGroups/pyansys/providers/Microsoft.Network/dnszones/pyansys.com/overview
+.. _PyAnsys Organization: https://github.com/ansys
 
 .. #Other libraries
 .. _Black: https://black.readthedocs.io/en/latest/
@@ -66,6 +85,13 @@
 .. _tox: https://tox.wiki/en/latest/
 .. _tox_repo: https://github.com/tox-dev/tox
 .. _make: https://www.gnu.org/software/make/
+.. _blacken-docs: https://github.com/asottile/blacken-docs
+.. _interrogate: https://interrogate.readthedocs.io/en/latest/
+.. _docstr-coverage: https://docstr-coverage.readthedocs.io/en/latest/index.html
+.. _docstring-coverage: https://bitbucket.org/DataGreed/docstring-coverage/wiki/Home
+.. _doctest: https://docs.python.org/3/library/doctest.html
+.. _docformatter: https://github.com/PyCQA/docformatter
+.. _pydocstyle: https://www.pydocstyle.org/en/stable/
 
 .. #External links
 .. _Docutils: https://docutils.sourceforge.io/
@@ -81,6 +107,7 @@
 .. _VSC_doc_setup: https://code.visualstudio.com/docs/setup/setup-overview
 .. _unzip: https://7-zip.org/
 .. _conventional_commit_types: https://github.com/commitizen/conventional-commit-types/blob/master/index.json
+.. _Test Driven Development (TDD): https://en.wikipedia.org/wiki/Test-driven_development
 
 .. #Sphinx-related links
 .. _PyData_Sphinx_theme: https://github.com/pydata/pydata-sphinx-theme
@@ -100,6 +127,7 @@
 .. _Sphinx_GS_doc: https://www.sphinx-doc.org/en/master/#get-started
 
 .. #Google dev doc guide links:
+.. _Google_dev_doc_style_guide: https://developers.google.com/style
 .. _Google_dev_doc_articles: https://developers.google.com/style/articles
 .. _Google_dev_doc_headings: https://developers.google.com/style/headings
 .. _Google_dev_doc_highlights: https://developers.google.com/style/highlights
@@ -118,6 +146,7 @@
 .. _GitHub Pages: https://pages.github.com/
 .. _GitHub Actions: https://github.com/features/actions
 .. _codecov: https://github.com/codecov
+.. _codecov.io: https://app.codecov.io/gh/pyansys
 .. _gh-pages: https://github.com/ansys/dev-guide/tree/gh-pages
 .. _enabling GitHub pages: https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site#creating-your-site
 .. _Creating a repository from a template: https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template
@@ -141,57 +170,29 @@
 .. _Namespace packages: https://packaging.python.org/guides/packaging-namespace-packages/
 .. _Python Packaging User Guide: https://packaging.python.org/en/latest/
 .. _Python Packaging Authority: https://www.pypa.io/en/latest/
-.. _PyAnsys: https://docs.pyansys.com/
-.. _PyMAPDL: https://github.com/ansys/pymapdl
-.. _ansys-api-mapdl: https://pypi.org/project/ansys-api-mapdl/
 .. _reStructuredText Markup Syntax: https://docutils.sourceforge.io/rst.html
 .. _Markdown Syntax: https://www.markdownguide.org/basic-syntax/
+.. _Style Guide for Python Code (PEP8): https://www.python.org/dev/peps/pep-0008
+.. _ImportError: https://docs.python.org/3/library/exceptions.html#ImportError
+.. _dunder methods: https://docs.python.org/3/reference/datamodel.html#special-method-names
+.. _PyPI: https://pypi.org/
+.. _pip Documentation: https://pip.pypa.io/en/stable/cli/pip_install/
+.. _Semantic Versioning: https://semver.org/
 
+.. #Other tools
 .. _Building and Distributing Packages with Setuptools: https://setuptools.pypa.io/en/latest/setuptools.html
 .. _Configuring setuptools using setup.cfg files: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
 .. _Setuptools: https://setuptools.pypa.io/en/latest/index.html
-
-.. _blacken-docs: https://github.com/asottile/blacken-docs
-.. _interrogate: https://interrogate.readthedocs.io/en/latest/
-.. _docstr-coverage: https://docstr-coverage.readthedocs.io/en/latest/index.html
-.. _docstring-coverage: https://bitbucket.org/DataGreed/docstring-coverage/wiki/Home
-.. _doctest: https://docs.python.org/3/library/doctest.html
-.. _docformatter: https://github.com/PyCQA/docformatter
-
-.. _pydocstyle: https://www.pydocstyle.org/en/stable/
-.. _ansys/template: https://github.com/ansys/template
-
 .. _gRPC: https://grpc.io/
 .. _pythoncom: http://timgolden.me.uk/pywin32-docs/pythoncom.html
 .. _SWIG: http://www.swig.org/
 .. _C extensions: https://docs.python.org/3/extending/extending.html
 .. _Anaconda Distribution: https://www.anaconda.com/products/individual
 .. _REST: https://en.wikipedia.org/wiki/Representational_state_transfer
-.. _PyAEDT: https://github.com/ansys/PyAEDT
-.. _Style Guide for Python Code (PEP8): https://www.python.org/dev/peps/pep-0008
-.. _grpc_chunk_stream_demo: https://github.com/ansys/grpc_chunk_stream_demo
-
-.. _ImportError: https://docs.python.org/3/library/exceptions.html#ImportError
-.. _dunder methods: https://docs.python.org/3/reference/datamodel.html#special-method-names
-
-.. _PyPI: https://pypi.org/
-.. _PyAnsys PyPI: https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi
-.. _pip Documentation: https://pip.pypa.io/en/stable/cli/pip_install/
-.. _Semantic Versioning: https://semver.org/
-
+.. _dependabot: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates
 .. _Flit: https://flit.pypa.io/en/latest/
 .. _flit pyproject.toml guidelines: https://flit.readthedocs.io/en/latest/pyproject_toml.html
 .. _Poetry: https://python-poetry.org/
 .. _poetry pyproject.toml documentation: https://python-poetry.org/docs/pyproject/
 .. _setuptools_repo: https://pypi.org/project/setuptools/
 .. _setuptools metadata fields: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#declarative-config
-
-.. _dependabot: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates
-
-.. _PyAnsys DNS Zones: https://portal.azure.com/#@ansys.com/resource/subscriptions/2870ae10-53f8-46b1-8971-93761377c38b/resourceGroups/pyansys/providers/Microsoft.Network/dnszones/pyansys.com/overview
-.. _Maxime Rey: https://teams.microsoft.com/l/chat/0/0?users=maxime.rey@ansys.com
-.. _Roberto Pastor Muela: https://teams.microsoft.com/l/chat/0/0?users=roberto.pastormuela@ansys.com
-.. _Alex Kaszynski: https://teams.microsoft.com/l/chat/0/0?users=alexander.kaszynski@ansys.com
-.. _PyAnsys Bot: https://github.com/apps/pyansys-bot
-.. _PyAnsys Organization: https://github.com/ansys
-.. _PyMeilisearch: https://pymeilisearch.docs.ansys.com/

--- a/doc/source/packaging/structure.rst
+++ b/doc/source/packaging/structure.rst
@@ -204,6 +204,9 @@ specific repository's ``AUTHORS`` file.
 
 .. include:: code/authors_code.rst
 
+
+.. _ref_changelog_file:
+
 The ``CHANGELOG.md`` file
 -------------------------
 

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -53,6 +53,7 @@ Microelectromechanical
 monospaced
 Muela
 [Nn]amespace
+npm
 numpy
 [Nn]umpydoc
 [Pp]arametrizing


### PR DESCRIPTION
As some repositories are enforcing the [conventional-commit standards](https://github.com/commitizen/conventional-commit-types/blob/master/index.json), this PR is to add a mention about it within our documentation.