### PR TITLE
fix: doc/source/how-to/releasing.rst: fix variables

### DIFF
--- a/doc/source/how-to/releasing.rst
+++ b/doc/source/how-to/releasing.rst
@@ -474,14 +474,14 @@ You can download artifacts from the Ansys private PyPI, public PyPI, and GitHub.
     
                     .. code-block:: powershell
     
-                        $env:INDEX_URL='https://$PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/'
+                        $env:INDEX_URL="https://$PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/"
                         python -m pip install ansys-<product/tool>-<library> --index-url $env:INDEX_URL --no-dependencies
     
         .. tab-item:: macOS
     
             .. code-block:: text
     
-                export INDEX_URL='https://$PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/'
+                export INDEX_URL="https://$PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/"
     
                 python -m pip install ansys-<product/tool>-<library> \
                 --index-url $INDEX_URL \
@@ -491,7 +491,7 @@ You can download artifacts from the Ansys private PyPI, public PyPI, and GitHub.
     
             .. code-block:: text
     
-                export INDEX_URL='https://$PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/'
+                export INDEX_URL="https://$PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/"
     
                 python -m pip install ansys-<product/tool>-<library> \
                 --index-url $INDEX_URL \

--- a/doc/source/how-to/releasing.rst
+++ b/doc/source/how-to/releasing.rst
@@ -474,7 +474,7 @@ You can download artifacts from the Ansys private PyPI, public PyPI, and GitHub.
     
                     .. code-block:: powershell
     
-                        $env:INDEX_URL="https://$PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/"
+                        $env:INDEX_URL="https://$env:PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/"
                         python -m pip install ansys-<product/tool>-<library> --index-url $env:INDEX_URL --no-dependencies
     
         .. tab-item:: macOS


### PR DESCRIPTION
- f0a6e25 `doc/source/how-to/releasing.rst`: use double quotes for variable expansion (otherwise `INDEX_URL` literally equals `https://$PYANSYS_PYPI_PRIVATE_READ_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/`)
- f002664 `doc/source/how-to/releasing.rst`: fix powershell nested variable