### PR TITLE
doc: rulesets for branch and tag naming

### DIFF
--- a/doc/source/how-to/contributing.rst
+++ b/doc/source/how-to/contributing.rst
@@ -206,6 +206,26 @@ changes any given branch is introducing before looking at the code.
 -  ``testing/`` or ``test/``: Improvements or changes to testing.
 -  ``release/``: Releases (see below).
 
+Enforcing branch-name conventions
+---------------------------------
+
+`GitHub rulesets
+<https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets>`_
+allow to enforce branch-name conventions. To do so, create a new ruleset named
+``conventional-commits``, then select the following configuration:
+
+- Enforcement status: ``Active``
+- Target branches: 
+  - Include: ``All branches``
+  - Exclude: ``main``, ``gh-pages``
+
+- Restrict branch names:
+    - Applies to: ``Branch name``
+    - Requirement: ``Must match a given regex pattern``
+    - Matching pattern: ``^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|dependabot|release)\/.*``
+    - Description: ``Branch name must match the conventional commits pattern``
+
+
 Push your branch
 ----------------
 

--- a/doc/source/how-to/contributing.rst
+++ b/doc/source/how-to/contributing.rst
@@ -206,26 +206,6 @@ changes any given branch is introducing before looking at the code.
 -  ``testing/`` or ``test/``: Improvements or changes to testing.
 -  ``release/``: Releases (see below).
 
-Enforcing branch-name conventions
----------------------------------
-
-`GitHub rulesets
-<https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets>`_
-allow to enforce branch-name conventions. To do so, create a new ruleset named
-``conventional-commits``, then select the following configuration:
-
-- Enforcement status: ``Active``
-- Target branches: 
-  - Include: ``All branches``
-  - Exclude: ``main``, ``gh-pages``
-
-- Restrict branch names:
-    - Applies to: ``Branch name``
-    - Requirement: ``Must match a given regex pattern``
-    - Matching pattern: ``^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|dependabot|release)\/.*``
-    - Description: ``Branch name must match the conventional commits pattern``
-
-
 Push your branch
 ----------------
 

--- a/doc/source/how-to/repository-protection.rst
+++ b/doc/source/how-to/repository-protection.rst
@@ -70,6 +70,20 @@ The PyAnsys core team recommends setting these rules for the ``main`` branch:
   go through and resolve all comments. This ensures that all comments are read and
   possibly applied.
 
+For other branches, conventional commits can be enforced by creating a rule
+with the following parameters:
+
+- Enforcement status: ``Active``
+- Target branches: 
+  - Include: ``All branches``
+  - Exclude: ``main``, ``gh-pages``
+
+- Restrict branch names:
+    - Applies to: ``Branch name``
+    - Requirement: ``Must match a given regex pattern``
+    - Matching pattern: ``^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|dependabot|release)\/.*``
+    - Description: ``Branch name must match the conventional commits pattern``
+
 Tag protection
 --------------
 


### PR DESCRIPTION
This pull-request documents how to use GitHub rulesets for enforcing branch names and tags.