### PR TITLE
doc: adjust contributors file wording

### DIFF
--- a/doc/source/packaging/code/contributors_file.md
+++ b/doc/source/packaging/code/contributors_file.md
@@ -1,6 +1,6 @@
 # Contributors
 
-## Project Lead or Owner
+## Project Lead
 
 * [First Last](https://github.com/ghusername)
 

--- a/doc/source/packaging/code/contributors_file.md
+++ b/doc/source/packaging/code/contributors_file.md
@@ -6,6 +6,4 @@
 
 ## Individual Contributors
 
-* [Jane Smith](https://github.com/janesmith)
-* [Jim Jones](https://github.com/jimjones)
-* [Jack Johnson](https://github.com/jackjohnson)
+* [First Last](https://github.com/ghusername)


### PR DESCRIPTION
Removed "or owner" from title and made the individual contributors generic. 

See [this PR](https://github.com/ansys/pre-commit-hooks/pull/233)