### PR TITLE
fix: allow for maint branches

### DIFF
--- a/doc/source/how-to/repository-protection.rst
+++ b/doc/source/how-to/repository-protection.rst
@@ -81,7 +81,7 @@ with the following parameters:
 - Restrict branch names:
     - Applies to: ``Branch name``
     - Requirement: ``Must match a given regex pattern``
-    - Matching pattern: ``^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|dependabot|release)\/.*``
+    - Matching pattern: ``^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|dependabot|release|maint)\/.*``
     - Description: ``Branch name must match the conventional commits pattern``
 
 Tag protection


### PR DESCRIPTION
As title says - we use this prefix in many of our repos and actions

PS: I know "maint" is not part of the standard but this is for branch naming conventions (not for commits per se). I think we should consider accepting it since we have used it for a long time and it englobes several miscellaneous operations IMO