### PR TITLE
fix: correct artifact upload target directories for html and pdf documentation

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -45,14 +45,14 @@ jobs:
         uses: actions/upload-artifact@v4.4.3
         with:
           name: HTML-Documentation
-          path: .tox/doc_out_html/
+          path: doc/_build/html
           retention-days: 7
 
       - name: Upload PDF Documentation
         uses: actions/upload-artifact@v4.4.3
         with:
           name: PDF-Documentation
-          path: doc/build/latex/pyansys*.pdf
+          path: doc/_build/latex/pyansys*.pdf
           retention-days: 7
 
       - name: Deploy to gh-pages


### PR DESCRIPTION
Expanding on the title, the directories being targeted by the action uploading the html and pdf documentation is incorrect. Corrected this (see the contents of tox.ini/Makefile).