### PR TITLE
fix: link to OSS request form

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -196,12 +196,15 @@ latex_elements = {"preamble": generate_preamble(html_title)}
 
 # Linkcheck configuration
 linkcheck_ignore = [
-    "https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi",  # Private URL hosting PyAnsys packages
-    "https://github.com/ansys-internal/.*",  # Private URL
-    "https://myapps.microsoft.com/signin/8f67c59b-83ac-4318-ae96-f0588382ddc0?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706",  # Join Ansys GitHub account
-    "https://myapps.microsoft.com/signin/42c0fa04-03f2-4407-865e-103af6973dae?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706",  # Join Ansys internal GitHub account
-    "https://opensource.org/licenses/MIT",  # Prevented from access
-    "https://www.gnu.org/software/make/",  # Prevented from access
+    # Needs user authentication
+    "https://myapps.microsoft.com/signin/8f67c59b-83ac-4318-ae96-f0588382ddc0?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706",
+    "https://myapps.microsoft.com/signin/42c0fa04-03f2-4407-865e-103af6973dae?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706",
+    "https://opensource.org/licenses/MIT",
+    "https://www.gnu.org/software/make/",
+    # Private links
+    "https://github.com/ansys-internal/.*",
+    "https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi",
+    "https://forms.office.com/r/HwZm15ApKQ",
 ]
 
 # Linkcheck ignore broken anchors

--- a/doc/source/getting-started/administration.rst
+++ b/doc/source/getting-started/administration.rst
@@ -9,7 +9,7 @@ First step
 ----------
 
 To trigger the public release process, project leads must first complete the
-`Release request workflow initiation form <https://ansys.typeform.com/ReleaseSupport?typeform-source=gz2idtcjsw2.typeform.com>`_.
+`Release request workflow initiation form <open-source request form>`_.
 
 This form lets the different parties involved in the public release process know that
 there is a request to release a project. If your intent is to release an Ansys open

--- a/doc/source/getting-started/administration.rst
+++ b/doc/source/getting-started/administration.rst
@@ -9,7 +9,7 @@ First step
 ----------
 
 To trigger the public release process, project leads must first complete the
-`Release request workflow initiation form <open-source request form>`_.
+`open source request form`_.
 
 This form lets the different parties involved in the public release process know that
 there is a request to release a project. If your intent is to release an Ansys open

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -36,6 +36,7 @@
 .. _ansys_help: https://ansyshelp.ansys.com
 .. _join_ansys_organization: https://myapps.microsoft.com/signin/8f67c59b-83ac-4318-ae96-f0588382ddc0?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706
 .. _join_ansys_internal_organization: https://myapps.microsoft.com/signin/42c0fa04-03f2-4407-865e-103af6973dae?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706
+.. _open-source request form: https://forms.office.com/r/HwZm15ApKQ
 
 .. #PyAnsys repositories
 .. _ansys-api-mapdl: https://pypi.org/project/ansys-api-mapdl/

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -36,7 +36,7 @@
 .. _ansys_help: https://ansyshelp.ansys.com
 .. _join_ansys_organization: https://myapps.microsoft.com/signin/8f67c59b-83ac-4318-ae96-f0588382ddc0?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706
 .. _join_ansys_internal_organization: https://myapps.microsoft.com/signin/42c0fa04-03f2-4407-865e-103af6973dae?tenantId=34c6ce67-15b8-4eff-80e9-52da8be89706
-.. _open-source request form: https://forms.office.com/r/HwZm15ApKQ
+.. _open source request form: https://forms.office.com/r/HwZm15ApKQ
 
 .. #PyAnsys repositories
 .. _ansys-api-mapdl: https://pypi.org/project/ansys-api-mapdl/


### PR DESCRIPTION
This pull-request updates the form for requesting an open-source release. The form is only accessible by ANSYS, Inc. employees.