### PR TITLE
chore: use ruff with ruff.toml file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-exclude = build, doc/source/conf.py
-select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E225, E231, E301, E303, E501, F401, F403
-count = True
-max-complexity = 10
-max-line-length = 100
-statistics = True

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@ documentation:
   - any-glob-to-any-file: ['doc/source/**/*']
 maintenance:
 - changed-files:
-  - any-glob-to-any-file: ['.github/**/*', '.flake8', 'pyproject.toml', 'docker/**/*']
+  - any-glob-to-any-file: ['.github/**/*', 'ruff.toml', 'pyproject.toml', 'docker/**/*']
 dependencies:
 - changed-files:
   - any-glob-to-any-file: ['requirements/*']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
   rev: v0.11.8
   hooks:
     - id: ruff
+    - id: ruff-format
 
 - repo: https://github.com/adamchainz/blacken-docs
   rev: 1.19.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,35 +1,16 @@
 repos:
 
 
-- repo: https://github.com/psf/black
-  rev: 25.1.0  # IF VERSION CHANGES --> MODIFY "blacken-docs" MANUALLY AS WELL!!
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.8
   hooks:
-  - id: black
-    args: [
-      "doc/source/conf.py",
-      "examples"
-    ]
+    - id: ruff
 
 - repo: https://github.com/adamchainz/blacken-docs
   rev: 1.19.1
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==24.8.0]
-
-- repo: https://github.com/pycqa/isort
-  rev: 6.0.1
-  hooks:
-  - id: isort
-    args: [
-      "--profile", "black",
-      "--force-sort-within-sections",
-      "--line-length", "100",
-    ]
-
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.2.0
-  hooks:
-  - id: flake8
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.1

--- a/doc/source/doc-style/code/sample_func.py
+++ b/doc/source/doc-style/code/sample_func.py
@@ -25,7 +25,7 @@ def func(arg1, arg2):
 
     Examples
     --------
-    >>> func(1, 'foo')
+    >>> func(1, "foo")
     True
 
     """

--- a/doc/source/doc-style/code/sample_func.py
+++ b/doc/source/doc-style/code/sample_func.py
@@ -1,4 +1,4 @@
-def func(arg1, arg2):
+def func(arg1, arg2):  # noqa: D100
     """Summary line <should be only one line>.
 
     Extended description of the function. The extended description,

--- a/doc/source/how-to/code/pyansys_logging.py
+++ b/doc/source/how-to/code/pyansys_logging.py
@@ -1,3 +1,5 @@
+"""Module for PyAnsys logging."""
+
 from copy import copy
 from datetime import datetime
 import logging
@@ -57,6 +59,7 @@ class InstanceCustomAdapter(logging.LoggerAdapter):
         self.std_out_handler = logger.std_out_handler
 
     def process(self, msg, kwargs):
+        """Get instance_name for logging."""
         kwargs["extra"] = {}
         # These are the extra parameters sent to log
         # here self.extra is the argument pass to the log records.
@@ -103,6 +106,8 @@ class InstanceCustomAdapter(logging.LoggerAdapter):
 
 
 class PyAnsysPercentStyle(logging.PercentStyle):
+    """Log message formatting."""
+
     def __init__(self, fmt, *, defaults=None):
         self._fmt = fmt or self.default_format
         self._defaults = defaults
@@ -151,6 +156,7 @@ class InstanceFilter(logging.Filter):
     """Ensures that instance_name record always exists."""
 
     def filter(self, record):
+        """If record had no attribute instance_name, create it and populate with empty string."""
         if not hasattr(record, "instance_name"):
             record.instance_name = ""
         return True
@@ -194,7 +200,7 @@ class Logger:
         self.logger.addFilter(InstanceFilter())
         self.logger.setLevel(level)
         self.logger.propagate = True
-        self.level = self.logger.level  # TODO: TO REMOVE
+        self.level = self.logger.level  # noqa: TD002, TD003 # TODO: TO REMOVE
 
         # Writing logging methods.
         self.debug = self.logger.debug
@@ -367,6 +373,7 @@ class Logger:
         return self._instances[new_name]
 
     def __getitem__(self, key):
+        """Define custom KeyError message."""
         if key in self._instances.keys():
             return self._instances[key]
         else:

--- a/doc/source/how-to/code/pyansys_logging.py
+++ b/doc/source/how-to/code/pyansys_logging.py
@@ -95,11 +95,11 @@ class InstanceCustomAdapter(logging.LoggerAdapter):
         self.logger = add_stdout_handler(self.logger, level=level)
         self.std_out_handler = self.logger.std_out_handler
 
-    def setLevel(self, level="DEBUG"):
+    def setlevel(self, level="DEBUG"):
         """Change the log level of the object and the attached handlers."""
-        self.logger.setLevel(level)
+        self.logger.setlevel(level)
         for each_handler in self.logger.handlers:
-            each_handler.setLevel(level)
+            each_handler.setlevel(level)
         self.level = level
 
 
@@ -194,7 +194,7 @@ class Logger:
 
         self.logger = logging.getLogger("pyproject_global")  # Creating default main logger.
         self.logger.addFilter(InstanceFilter())
-        self.logger.setLevel(level)
+        self.logger.setlevel(level)
         self.logger.propagate = True
         self.level = self.logger.level  # TODO: TO REMOVE
 
@@ -243,11 +243,11 @@ class Logger:
 
         self = add_stdout_handler(self, level=level)
 
-    def setLevel(self, level="DEBUG"):
+    def setlevel(self, level="DEBUG"):
         """Change the log level of the object and the attached handlers."""
-        self.logger.setLevel(level)
+        self.logger.setlevel(level)
         for each_handler in self.logger.handlers:
-            each_handler.setLevel(level)
+            each_handler.setlevel(level)
         self._level = level
 
     def _make_child_logger(self, suffix, level):
@@ -276,17 +276,17 @@ class Logger:
                     # loglevel if the specified log level is lower
                     # than the one of the global.
                     if each_handler.level > string_to_loglevel[level.upper()]:
-                        new_handler.setLevel(level)
+                        new_handler.setlevel(level)
 
                 logger.addHandler(new_handler)
 
         if level:
             if isinstance(level, str):
                 level = string_to_loglevel[level.upper()]
-            logger.setLevel(level)
+            logger.setlevel(level)
 
         else:
-            logger.setLevel(self.logger.level)
+            logger.setlevel(self.logger.level)
 
         logger.propagate = True
         return logger
@@ -395,7 +395,7 @@ class Logger:
                 for handler in self.logger.handlers:
                     handler.close()
                     self.logger.removeHandler(handler)
-            except Exception as e:
+            except Exception:
                 try:
                     if self.logger is not None:
                         self.logger.error("The logger was not deleted properly.")
@@ -426,7 +426,7 @@ def add_file_handler(logger, filename=FILE_NAME, level=LOG_LEVEL, write_headers=
     """
 
     file_handler = logging.FileHandler(filename)
-    file_handler.setLevel(level)
+    file_handler.setlevel(level)
     file_handler.setFormatter(logging.Formatter(FILE_MSG_FORMAT))
 
     if isinstance(logger, Logger):
@@ -463,7 +463,7 @@ def add_stdout_handler(logger, level=LOG_LEVEL, write_headers=False):
     """
 
     std_out_handler = logging.StreamHandler(sys.stdout)
-    std_out_handler.setLevel(level)
+    std_out_handler.setlevel(level)
     std_out_handler.setFormatter(PyProjectFormatter(STDOUT_MSG_FORMAT))
 
     if isinstance(logger, Logger):

--- a/doc/source/how-to/code/pyansys_logging.py
+++ b/doc/source/how-to/code/pyansys_logging.py
@@ -94,11 +94,11 @@ class InstanceCustomAdapter(logging.LoggerAdapter):
         self.logger = add_stdout_handler(self.logger, level=level)
         self.std_out_handler = self.logger.std_out_handler
 
-    def setlevel(self, level="DEBUG"):
+    def setLevel(self, level="DEBUG"):
         """Change the log level of the object and the attached handlers."""
-        self.logger.setlevel(level)
+        self.logger.setLevel(level)
         for each_handler in self.logger.handlers:
-            each_handler.setlevel(level)
+            each_handler.setLevel(level)
         self.level = level
 
 
@@ -192,7 +192,7 @@ class Logger:
         """Initialize Logger class."""
         self.logger = logging.getLogger("pyproject_global")  # Creating default main logger.
         self.logger.addFilter(InstanceFilter())
-        self.logger.setlevel(level)
+        self.logger.setLevel(level)
         self.logger.propagate = True
         self.level = self.logger.level  # TODO: TO REMOVE
 
@@ -373,7 +373,7 @@ class Logger:
             raise KeyError(f"There are no instances with name {key}")
 
     def add_handling_uncaught_expections(self, logger):
-        """Just redirects the output of an exception to the logger."""
+        """Redirect the output of an exception to the logger."""
 
         def handle_exception(exc_type, exc_value, exc_traceback):
             if issubclass(exc_type, KeyboardInterrupt):

--- a/doc/source/how-to/code/pyansys_logging.py
+++ b/doc/source/how-to/code/pyansys_logging.py
@@ -239,11 +239,11 @@ class Logger:
         """
         self = add_stdout_handler(self, level=level)
 
-    def setlevel(self, level="DEBUG"):
+    def setLevel(self, level="DEBUG"):
         """Change the log level of the object and the attached handlers."""
-        self.logger.setlevel(level)
+        self.logger.setLevel(level)
         for each_handler in self.logger.handlers:
-            each_handler.setlevel(level)
+            each_handler.setLevel(level)
         self._level = level
 
     def _make_child_logger(self, suffix, level):
@@ -272,17 +272,17 @@ class Logger:
                     # loglevel if the specified log level is lower
                     # than the one of the global.
                     if each_handler.level > string_to_loglevel[level.upper()]:
-                        new_handler.setlevel(level)
+                        new_handler.setLevel(level)
 
                 logger.addHandler(new_handler)
 
         if level:
             if isinstance(level, str):
                 level = string_to_loglevel[level.upper()]
-            logger.setlevel(level)
+            logger.setLevel(level)
 
         else:
-            logger.setlevel(self.logger.level)
+            logger.setLevel(self.logger.level)
 
         logger.propagate = True
         return logger
@@ -421,7 +421,7 @@ def add_file_handler(logger, filename=FILE_NAME, level=LOG_LEVEL, write_headers=
         Return the logger or Logger object.
     """
     file_handler = logging.FileHandler(filename)
-    file_handler.setlevel(level)
+    file_handler.setLevel(level)
     file_handler.setFormatter(logging.Formatter(FILE_MSG_FORMAT))
 
     if isinstance(logger, Logger):
@@ -457,7 +457,7 @@ def add_stdout_handler(logger, level=LOG_LEVEL, write_headers=False):
         The logger or Logger object.
     """
     std_out_handler = logging.StreamHandler(sys.stdout)
-    std_out_handler.setlevel(level)
+    std_out_handler.setLevel(level)
     std_out_handler.setFormatter(PyProjectFormatter(STDOUT_MSG_FORMAT))
 
     if isinstance(logger, Logger):

--- a/doc/source/how-to/code/pyansys_logging.py
+++ b/doc/source/how-to/code/pyansys_logging.py
@@ -10,9 +10,7 @@ FILE_NAME = "PyProject.log"
 
 
 # Formatting
-STDOUT_MSG_FORMAT = (
-    "%(levelname)s - %(instance_name)s - %(module)s - %(funcName)s - %(message)s"
-)
+STDOUT_MSG_FORMAT = "%(levelname)s - %(instance_name)s - %(module)s - %(funcName)s - %(message)s"
 FILE_MSG_FORMAT = STDOUT_MSG_FORMAT
 
 DEFAULT_STDOUT_HEADER = """
@@ -194,9 +192,7 @@ class Logger:
     ):
         """Initialize Logger class."""
 
-        self.logger = logging.getLogger(
-            "pyproject_global"
-        )  # Creating default main logger.
+        self.logger = logging.getLogger("pyproject_global")  # Creating default main logger.
         self.logger.addFilter(InstanceFilter())
         self.logger.setLevel(level)
         self.logger.propagate = True
@@ -234,9 +230,7 @@ class Logger:
             Level of logging. E.x. 'DEBUG'. By default LOG_LEVEL
         """
 
-        self = add_file_handler(
-            self, filename=filename, level=level, write_headers=True
-        )
+        self = add_file_handler(self, filename=filename, level=level, write_headers=True)
 
     def log_to_stdout(self, level=LOG_LEVEL):
         """Add standard output handler to the logger.
@@ -333,9 +327,7 @@ class Logger:
                 self._make_child_logger("NO_NAMED_YET", level), product_instance
             )
         else:
-            raise TypeError(
-                f"``name`` parameter must be a string or None, not f{type(name)}"
-            )
+            raise TypeError(f"``name`` parameter must be a string or None, not f{type(name)}")
 
         return instance_logger
 
@@ -391,9 +383,7 @@ class Logger:
             if issubclass(exc_type, KeyboardInterrupt):
                 sys.__excepthook__(exc_type, exc_value, exc_traceback)
                 return
-            logger.critical(
-                "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
-            )
+            logger.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
 
         sys.excepthook = handle_exception
 

--- a/doc/source/how-to/code/pyansys_logging.py
+++ b/doc/source/how-to/code/pyansys_logging.py
@@ -75,7 +75,6 @@ class InstanceCustomAdapter(logging.LoggerAdapter):
             Level of logging, for example ``'DEBUG'``. By default
             ``logging.DEBUG``.
         """
-
         self.logger = add_file_handler(
             self.logger, filename=filename, level=level, write_headers=True
         )
@@ -191,7 +190,6 @@ class Logger:
         cleanup=True,
     ):
         """Initialize Logger class."""
-
         self.logger = logging.getLogger("pyproject_global")  # Creating default main logger.
         self.logger.addFilter(InstanceFilter())
         self.logger.setlevel(level)
@@ -229,7 +227,6 @@ class Logger:
         level : str, optional
             Level of logging. E.x. 'DEBUG'. By default LOG_LEVEL
         """
-
         self = add_file_handler(self, filename=filename, level=level, write_headers=True)
 
     def log_to_stdout(self, level=LOG_LEVEL):
@@ -240,7 +237,6 @@ class Logger:
         level : str, optional
             Level of logging record. By default LOG_LEVEL
         """
-
         self = add_stdout_handler(self, level=level)
 
     def setlevel(self, level="DEBUG"):
@@ -377,7 +373,7 @@ class Logger:
             raise KeyError(f"There are no instances with name {key}")
 
     def add_handling_uncaught_expections(self, logger):
-        """This just redirects the output of an exception to the logger."""
+        """Just redirects the output of an exception to the logger."""
 
         def handle_exception(exc_type, exc_value, exc_traceback):
             if issubclass(exc_type, KeyboardInterrupt):
@@ -424,7 +420,6 @@ def add_file_handler(logger, filename=FILE_NAME, level=LOG_LEVEL, write_headers=
     logger
         Return the logger or Logger object.
     """
-
     file_handler = logging.FileHandler(filename)
     file_handler.setlevel(level)
     file_handler.setFormatter(logging.Formatter(FILE_MSG_FORMAT))
@@ -461,7 +456,6 @@ def add_stdout_handler(logger, level=LOG_LEVEL, write_headers=False):
     logger
         The logger or Logger object.
     """
-
     std_out_handler = logging.StreamHandler(sys.stdout)
     std_out_handler.setlevel(level)
     std_out_handler.setFormatter(PyProjectFormatter(STDOUT_MSG_FORMAT))

--- a/doc/source/how-to/code/test_pyansys_logging.py
+++ b/doc/source/how-to/code/test_pyansys_logging.py
@@ -21,7 +21,7 @@ def test_default_logger():
 
     assert "INFO -  - test_pyansys_logging - test_default_logger - Test stdout" in capture.content
     # File handlers are not activated.
-    assert Path.exists(Path.exists(Path(Path.cwd() / "PyProject.log")))
+    assert (Path.cwd() / "PyProject.log").exists()
 
 
 def test_level_stdout():

--- a/doc/source/how-to/code/test_pyansys_logging.py
+++ b/doc/source/how-to/code/test_pyansys_logging.py
@@ -16,10 +16,7 @@ def test_default_logger():
         test_logger = pyansys_logging.Logger()
         test_logger.info("Test stdout")
 
-    assert (
-        "INFO -  - test_pyansys_logging - test_default_logger - Test stdout"
-        in capture.content
-    )
+    assert "INFO -  - test_pyansys_logging - test_default_logger - Test stdout" in capture.content
     # File handlers are not activated.
     assert os.path.exists(os.path.exists(os.path.join(os.getcwd(), "PyProject.log")))
 
@@ -99,9 +96,7 @@ def test_file_handlers(tmpdir):
     with open(file_logger, "r") as f:
         content = f.readlines()
 
-    assert os.path.exists(
-        file_logger
-    )  # The file handler is not the default PyProject.Log
+    assert os.path.exists(file_logger)  # The file handler is not the default PyProject.Log
     assert len(content) == 6
     assert "NEW SESSION" in content[2]
     assert (
@@ -109,10 +104,7 @@ def test_file_handlers(tmpdir):
         in content[3]
     )
     assert "LEVEL - INSTANCE NAME - MODULE - FUNCTION - MESSAGE" in content[4]
-    assert (
-        "INFO -  - test_pyansys_logging - test_file_handlers - Test Misc File"
-        in content[5]
-    )
+    assert "INFO -  - test_pyansys_logging - test_file_handlers - Test Misc File" in content[5]
 
     # Delete the logger and its file handler.
     test_logger_ref = weakref.ref(test_logger)

--- a/doc/source/how-to/code/test_pyansys_logging.py
+++ b/doc/source/how-to/code/test_pyansys_logging.py
@@ -1,6 +1,6 @@
 import io
 import logging
-import os
+from pathlib import Path
 import sys
 import weakref
 
@@ -9,8 +9,9 @@ import pyansys_logging
 
 def test_default_logger():
     """Create a logger with default options.
-    Only stdout logger must be used."""
 
+    Only stdout logger must be used.
+    """
     capture = CaptureStdOut()
     with capture:
         test_logger = pyansys_logging.Logger()
@@ -18,13 +19,14 @@ def test_default_logger():
 
     assert "INFO -  - test_pyansys_logging - test_default_logger - Test stdout" in capture.content
     # File handlers are not activated.
-    assert os.path.exists(os.path.exists(os.path.join(os.getcwd(), "PyProject.log")))
+    assert Path.exists(Path.exists(Path(Path.cwd() / "PyProject.log")))
 
 
 def test_level_stdout():
     """Create a logger with default options.
-    Only stdout logger must be used."""
 
+    Only stdout logger must be used.
+    """
     capture = CaptureStdOut()
     with capture:
         test_logger = pyansys_logging.Logger(level=logging.INFO)
@@ -82,21 +84,20 @@ def test_level_stdout():
     )
 
     # File handlers are not activated.
-    assert os.path.exists(os.path.exists(os.path.join(os.getcwd(), "PyProject.log")))
+    assert Path.exists(Path.exists(Path(Path.cwd() / "PyProject.log")))
 
 
 def test_file_handlers(tmpdir):
     """Activate a file handler different from `PyProject.log`."""
-
     file_logger = tmpdir.mkdir("sub").join("test_logger.txt")
 
     test_logger = pyansys_logging.Logger(to_file=True, filename=file_logger)
     test_logger.info("Test Misc File")
 
-    with open(file_logger, "r") as f:
+    with Path.open(file_logger, "r") as f:
         content = f.readlines()
 
-    assert os.path.exists(file_logger)  # The file handler is not the default PyProject.Log
+    assert Path.exists(file_logger)  # The file handler is not the default PyProject.Log
     assert len(content) == 6
     assert "NEW SESSION" in content[2]
     assert (

--- a/doc/source/how-to/code/test_pyansys_logging.py
+++ b/doc/source/how-to/code/test_pyansys_logging.py
@@ -84,7 +84,7 @@ def test_level_stdout():
     )
 
     # File handlers are not activated.
-    assert Path.exists(Path.exists(Path(Path.cwd() / "PyProject.log")))
+    assert (Path.cwd() / "PyProject.log").exists()
 
 
 def test_file_handlers(tmpdir):

--- a/doc/source/how-to/code/test_pyansys_logging.py
+++ b/doc/source/how-to/code/test_pyansys_logging.py
@@ -1,3 +1,5 @@
+"""Test for PyAnsys logging."""
+
 import io
 import logging
 from pathlib import Path
@@ -120,9 +122,11 @@ class CaptureStdOut:
         self._stream = io.StringIO()
 
     def __enter__(self):
+        """Runtime context is entered."""
         sys.stdout = self._stream
 
     def __exit__(self, type, value, traceback):
+        """Runtime context is exited."""
         sys.stdout = sys.__stdout__
 
     @property

--- a/examples/pyvista_example.py
+++ b/examples/pyvista_example.py
@@ -21,8 +21,9 @@
 # SOFTWARE.
 
 """
-Adding a new gallery example.
+.. _adding_a_new_gallery_example:
 
+Adding a new gallery example
 ============================
 
 This example shows how to add a new example to the PyAnsys `Sphinx-Gallery

--- a/examples/pyvista_example.py
+++ b/examples/pyvista_example.py
@@ -21,9 +21,8 @@
 # SOFTWARE.
 
 """
-.. _adding_a_new_gallery_example:
+Adding a new gallery example.
 
-Adding a new gallery example
 ============================
 
 This example shows how to add a new example to the PyAnsys `Sphinx-Gallery

--- a/examples/pyvista_example.py
+++ b/examples/pyvista_example.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# ruff: noqa: D400
 """
 .. _adding_a_new_gallery_example:
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,15 +13,17 @@ docstring-code-format = true
 [lint]
 select = [
     "E",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
-    "I",    # isort, see https://docs.astral.sh/ruff/rules/#isort-i
-]
-ignore = [
-    "D",    # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
     "F",    # pyflakes, see https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "I",    # isort, see https://docs.astral.sh/ruff/rules/#isort-i
     "N",    # pep8-naming, see https://docs.astral.sh/ruff/rules/#pep8-naming-n
-    "PTH",  # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "TD",   # flake8-todos, https://docs.astral.sh/ruff/rules/#flake8-todos-td
     "W",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+]
+ignore = [
+    "D",     # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "PTH",   # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "TD002", # Missing author in TODOs comment
+    "TD003", # Missing issue link in TODOs comment
 ]
 
 [lint.pydocstyle]

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,12 +12,12 @@ docstring-code-format = true
 
 [lint]
 select = [
-    "D",     # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "D",    # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
     "E",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
     "F",    # pyflakes, see https://docs.astral.sh/ruff/rules/#pyflakes-f
     "I",    # isort, see https://docs.astral.sh/ruff/rules/#isort-i
     "N",    # pep8-naming, see https://docs.astral.sh/ruff/rules/#pep8-naming-n
-    "PTH",   # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "PTH",  # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "TD",   # flake8-todos, https://docs.astral.sh/ruff/rules/#flake8-todos-td
     "W",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
 ]
@@ -40,3 +40,6 @@ force-sort-within-sections = true
 
 [lint.mccabe]
 max-complexity = 10
+
+[lint.pep8-naming]
+ignore-names = ["setLevel"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -26,6 +26,7 @@ ignore = [
     "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
     "D105",  # Missing docstring in magic method
+    "D400",  # First line should end with a period
     "TD002", # Missing author in TODOs comment
     "TD003", # Missing issue link in TODOs comment
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,35 @@
+exclude = [
+    "build",
+    "doc/source/conf.py",
+]
+
+line-length = 100
+
+[format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+
+[lint]
+select = [
+    "E",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "I",    # isort, see https://docs.astral.sh/ruff/rules/#isort-i
+]
+ignore = [
+    "D",    # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "F",    # pyflakes, see https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "N",    # pep8-naming, see https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "PTH",  # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "TD",   # flake8-todos, https://docs.astral.sh/ruff/rules/#flake8-todos-td
+    "W",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+]
+
+[lint.pydocstyle]
+convention = "numpy"
+
+[lint.isort]
+combine-as-imports = true
+force-sort-within-sections = true
+
+[lint.mccabe]
+max-complexity = 10

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,16 +12,20 @@ docstring-code-format = true
 
 [lint]
 select = [
+    "D",     # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
     "E",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
     "F",    # pyflakes, see https://docs.astral.sh/ruff/rules/#pyflakes-f
     "I",    # isort, see https://docs.astral.sh/ruff/rules/#isort-i
     "N",    # pep8-naming, see https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "PTH",   # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "TD",   # flake8-todos, https://docs.astral.sh/ruff/rules/#flake8-todos-td
     "W",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
 ]
 ignore = [
-    "D",     # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
-    "PTH",   # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "D100",  # Missing docstring in public module
+    "D101",  # Missing docstring in public class
+    "D102",  # Missing docstring in public method
+    "D105",  # Missing docstring in magic method
     "TD002", # Missing author in TODOs comment
     "TD003", # Missing issue link in TODOs comment
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -21,15 +21,7 @@ select = [
     "TD",   # flake8-todos, https://docs.astral.sh/ruff/rules/#flake8-todos-td
     "W",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
 ]
-ignore = [
-    "D100",  # Missing docstring in public module
-    "D101",  # Missing docstring in public class
-    "D102",  # Missing docstring in public method
-    "D105",  # Missing docstring in magic method
-    "D400",  # First line should end with a period
-    "TD002", # Missing author in TODOs comment
-    "TD003", # Missing issue link in TODOs comment
-]
+ignore = []
 
 [lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
This PR implements the change discussed in #593, i.e. migrating the pyansys-dev-guide to Ruff.

The specific configs for Black, isort and flake8 are removed and the .pre-commit-config.yaml file is updated accordingly, while a ruff.toml file defining the rules used by Ruff for linting and formatting is introduced.
Python files fixed by Ruff are updated.

Since the project does not currently contain a pyproject.toml file, it was decided not to define one for the purpose of holding the Ruff configuration, but instead to specify it in a ruff.toml file placed at the root of the project. The introduction of a pyproject.toml file is considered to be beyond the scope of this PR, which is the motivation for this choice.
Should a pyproject.toml file be created in the future, the content of the ruff.toml can simply be added to it and this config file removed.

As indicated in #593, the use of blacken-docs in .pre-commit-config.yaml is maintained as this tool (used for formatting Python code blocks in documentation files) cannot currently be replaced by Ruff, which does not support formatting/linting of embedded code (particularly in .rst or .md files, see https://github.com/astral-sh/ruff/issues/8237). Similarly, blacken-docs does not support the Ruff formatter as an alternative for Black (see https://github.com/adamchainz/blacken-docs/issues/352).
This tool is therefore retained (see here about the Ruff pre-commit hook https://github.com/astral-sh/ruff-pre-commit/issues/55) for this project, despite the remaining dependence on Black.

Close #593 