### PR TITLE
feat: add doc on pinning GitHub actions

### DIFF
--- a/doc/source/getting-started/administration.rst
+++ b/doc/source/getting-started/administration.rst
@@ -180,6 +180,7 @@ The PyAnsys core team performs these checks when performing the technical review
     | |uncheck| :ref:`Branch protection` is enabled.
     | |uncheck| :ref:`Tag protection` is enabled.
     | |uncheck| :ref:`Workflow protection` is enabled.
+    | |uncheck| :ref:`Pin actions with full-length commit SHA` is enabled.
 
 
 .. |check| raw:: html

--- a/doc/source/how-to/repository-protection.rst
+++ b/doc/source/how-to/repository-protection.rst
@@ -132,3 +132,19 @@ their PR workflows do not have to be accepted every time that they intend to run
 
 Internal and private repositories are only available to organization users and repository members,
 respectively. Thus, no specific rules for outside collaborators are needed.
+
+Pin actions with full-length commit SHA
+---------------------------------------
+
+Protect your workflows by requiring actions to be pinned to a full-length commit SHA.
+To enable the setting **Require actions to be pinned to a full-length commit SHA**, select
+**Settings > Actions > General** and see the **Actions permissions** section.
+
+When this option is active, all GitHub Actions used in workflows must reference a specific
+commit hash, for example `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2` instead
+of a moving tag such as `v4`. The main advantage of this option is supply chain security. Indeed, tags
+are mutable in the sense that an attacker who gains access to a project, or even a legitimate maintainer
+updating a tag, could introduce breaking changes or malicious code without you noticing. Pinning to a
+commit SHA eliminates that risk by locking the dependency to a known version. On top of that, since the
+action's code cannot change silently in the background, it guarantees that every workflow run uses the
+exact same version of the action.


### PR DESCRIPTION
I just discovered that GitHub has (now) a setting for enforcing the use of pinned actions. The drawbacks with enabling this setting are:
- additional maintenance as the number of dependabot PR will increase, but the pros are totally worth it;
- our ansys/actions will have to be pinned as the rest of the actions - this could be controversial for some developers that believe they can use our actions without checking the changes.

The option is on the bottom right of the screen
<img width="1492" height="553" alt="image" src="https://github.com/user-attachments/assets/fee027b1-f9db-4e41-ae6b-b5b9fb3d4bfe" />
