### PR TITLE
docs: bandit disclaimer

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -211,6 +211,9 @@ linkcheck_ignore = [
     "https://github.com/ansys-internal/.*",
     "https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi",
     "https://forms.office.com/r/HwZm15ApKQ",
+    # Bot access prevented
+    "https://github.com/signup",
+    "https://github.com/join",
 ]
 
 # Linkcheck ignore broken anchors

--- a/doc/source/how-to/vulnerabilities.rst
+++ b/doc/source/how-to/vulnerabilities.rst
@@ -162,7 +162,7 @@ should be avoided. Refer to the `blacklists Bandit documentation`_ for detailed 
 
 .. info::
 
-   The PyAnsys dev guide recomments to leverage the ``bandit`` scan checks only focus on the source code
+   The PyAnsys dev guide recommends to leverage the ``bandit`` scan checks only focus on the source code
    folder of the project, and not on other directories containing Python code which might not be relevant
    for end users - such as the tests directory. This can be achieved by running ``bandit -r src/ ...``
 

--- a/doc/source/how-to/vulnerabilities.rst
+++ b/doc/source/how-to/vulnerabilities.rst
@@ -160,7 +160,7 @@ not be used in Python code. Using these functions can lead to security vulnerabi
 should be avoided. Refer to the `blacklists Bandit documentation`_ for detailed information on
 `Bandit` tool outputs.
 
-.. info::
+.. note::
 
    The PyAnsys dev guide recommends to leverage the ``bandit`` scan checks only focus on the source code
    folder of the project, and not on other directories containing Python code which might not be relevant

--- a/doc/source/how-to/vulnerabilities.rst
+++ b/doc/source/how-to/vulnerabilities.rst
@@ -162,7 +162,7 @@ should be avoided. Refer to the `blacklists Bandit documentation`_ for detailed 
 
 .. note::
 
-   The PyAnsys dev guide recommends to leverage the ``bandit`` scan checks only focus on the source code
+   The PyAnsys dev guide recommends to leverage the ``bandit`` scan checks only to focus on the source code
    folder of the project, and not on other directories containing Python code which might not be relevant
    for end users - such as the tests directory. This can be achieved by running ``bandit -r src/ ...``
 

--- a/doc/source/how-to/vulnerabilities.rst
+++ b/doc/source/how-to/vulnerabilities.rst
@@ -160,6 +160,11 @@ not be used in Python code. Using these functions can lead to security vulnerabi
 should be avoided. Refer to the `blacklists Bandit documentation`_ for detailed information on
 `Bandit` tool outputs.
 
+.. info::
+
+   The PyAnsys dev guide recomments to leverage the ``bandit`` scan checks only focus on the source code
+   folder of the project, and not on other directories containing Python code which might not be relevant
+   for end users - such as the tests directory. This can be achieved by running ``bandit -r src/ ...``
 
 **Bandit blacklist**
 


### PR DESCRIPTION
Adding bandit usage disclaimer into our dev docs. We should avoid running it everywhere..