### PR TITLE
docs: update links and add python manager link

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -208,7 +208,7 @@ linkcheck_ignore = [
     "https://www.gnu.org/software/make/",
     "https://docutils.sourceforge.io/.*",
     # Private links
-    "https://github.com/ansys-internal/.*",
+    "https://github.com/ansys/.*/pull/.*",
     "https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi",
     "https://forms.office.com/r/HwZm15ApKQ",
     # Bot access prevented

--- a/doc/source/how-to/deprecating.rst
+++ b/doc/source/how-to/deprecating.rst
@@ -93,10 +93,10 @@ is used in this guide.
           "This library is deprecated and will no longer be maintained. "
           "Please consider using alternatives. "
           "For more information check https://github.com/ansys/<repository>/issues/<number>",
-          DeprecationWarning,
+          FutureWarning,
       )
 
-   See an example at `PyAdditive Widgets deprecation warning`_.
+   See an example at `PySeascape deprecation warning`_.
 
 6. **(Optional) Adapt the documentation**: PyAnsys libraries host documentation in GitHub Pages through
    the ``gh-pages`` branch. If your library has documentation, consider adding a deprecation notice
@@ -137,9 +137,10 @@ The PyAnsys Core team is responsible for assisting with the deprecation process 
 - Assisting with the preceding steps, if necessary.
 - Remove from PyPI the configuration (PyPI token or trusted publisher) for the library.
 - Archive the project on PyPI. See `PyAdditive Widgets PyPI archive`_.
-- Removing the library from the `PyAnsys metapackage <metapackage_>`_, automation project
-  and the ``pyansys-dev`` repository. See example pull requests:
+- Removing the library from the `PyAnsys metapackage <metapackage_>`_, automation project,
+  the ``pyansys-dev`` repository and the python manager. See example pull requests:
 
   - `Metapackage deprecation PR`_
   - `PyAnsys Dev deprecation PR`_
   - `Automation project deprecation PR`_
+  - `Python Manager PR`_

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -241,8 +241,9 @@
 .. #Deprecation
 .. _PyAdditive Widgets README: https://github.com/ansys/pyadditive-widgets/blob/main/README.rst
 .. _PyAdditive Widgets deprecation issue: https://github.com/ansys/pyadditive-widgets/issues/102
-.. _PyAdditive Widgets deprecation warning: https://github.com/ansys/pyadditive-widgets/blob/600915a8db2dbb02088266c17ba2be53584079d0/src/ansys/additive/widgets/__init__.py#L24-L31
+.. _PySeascape deprecation warning: https://github.com/ansys/pyseascape/blob/6332624c532ec58805923a716599b097b6a980bc/src/ansys/seascape/__init__.py#L29-L32
 .. _PyAdditive Widgets PyPI archive: https://pypi.org/project/ansys-additive-widgets/
 .. _Metapackage deprecation PR: https://github.com/ansys/pyansys/pull/968
-.. _PyAnsys Dev deprecation PR: https://github.com/ansys-internal/pyansys-dev/pull/44
-.. _Automation project deprecation PR: https://github.com/ansys-internal/pyansys-maintenance-automation/pull/79
+.. _PyAnsys Dev deprecation PR: https://github.com/ansys/pyansys-dev/pull/44
+.. _Automation project deprecation PR: https://github.com/ansys/pyansys-maintenance-automation/pull/79
+.. _Python Manager PR: https://github.com/ansys/python-installer-qt-gui/pull/638


### PR DESCRIPTION
Updates some links to reflect the change of warning,  project migration and additional task to perform.